### PR TITLE
Time visibility property

### DIFF
--- a/src/System/Time/Now.php
+++ b/src/System/Time/Now.php
@@ -2,23 +2,55 @@
 
 namespace System\Time;
 
+/**
+ * @property int    $timestamp
+ * @property int    $year
+ * @property int    $month
+ * @property int    $day
+ * @property int    $hour
+ * @property int    $minute
+ * @property int    $second
+ * @property string $monthName
+ * @property string $dayName
+ * @property string $timeZone
+ * @property int    $age
+ */
 class Now
 {
+    /**
+     * Timestime.
+     *
+     * @var int|false
+     */
     private $time;
+
     // public
-    public $timestamp;
-    public $year;
-    public $month;
-    public $day;
-    public $hour;
-    public $minute;
-    public $second;
+    /** @var int|false */
+    private $timestamp;
+    /** @var int */
+    private $year;
+    /** @var int */
+    private $month;
+    /** @var int */
+    private $day;
+    /** @var int */
+    private $hour;
+    /** @var int */
+    private $minute;
+    /** @var int */
+    private $second;
+
     // other format date
-    public $monthName;
-    public $dayName;
-    public $timeZone;
+    /** @var string */
+    private $monthName;
+    /** @var string */
+    private $dayName;
+    /** @var string */
+    private $timeZone;
+
     // other property
-    public $age;
+    /** @var int|float */
+    private $age;
 
     public function __construct(string $date_format = 'now')
     {
@@ -31,20 +63,58 @@ class Now
     public function __toString()
     {
         return implode('T', [
-      date('Y-m-d', $this->time),
-      date('H:i:s', $this->time),
-    ]);
+            date('Y-m-d', $this->time),
+            date('H:i:s', $this->time),
+        ]);
     }
 
+    /**
+     * Get private property.
+     *
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        if (property_exists($this, $name)) {
+            return $this->{$name};
+        }
+
+        return null;
+    }
+
+    /**
+     * Set property by pase the `refresh` logic.
+     *
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @return self
+     */
+    public function __set($name, $value)
+    {
+        if (method_exists($this, $name) && property_exists($this, $name)) {
+            $this->{$name}($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Refresh property with current time.
+     *
+     * @return void
+     */
     private function refresh()
     {
         $this->timestamp = $this->time;
-        $this->year      = date('Y', $this->time);
-        $this->month     = date('n', $this->time);
-        $this->day       = date('d', $this->time);
-        $this->hour      = date('H', $this->time);
-        $this->minute    = date('i', $this->time);
-        $this->second    = date('s', $this->time);
+        $this->year      = (int) date('Y', $this->time);
+        $this->month     = (int) date('n', $this->time);
+        $this->day       = (int) date('d', $this->time);
+        $this->hour      = (int) date('H', $this->time);
+        $this->minute    = (int) date('i', $this->time);
+        $this->second    = (int) date('s', $this->time);
 
         $this->monthName = date('F', $this->time);
         $this->dayName   = date('l', $this->time);
@@ -54,91 +124,121 @@ class Now
         $this->age = abs(floor($age / (365 * 60 * 60 * 24)));
     }
 
+    /**
+     * Set year time.
+     *
+     * @return self
+     */
     public function year(int $year)
     {
         $this->time = mktime(
-      $this->hour,
-      $this->minute,
-      $this->second,
-      $this->month,
-      $this->day,
-      $year
-    );
+            $this->hour,
+            $this->minute,
+            $this->second,
+            $this->month,
+            $this->day,
+            $year
+        );
         $this->refresh();
 
         return $this;
     }
 
+    /**
+     * set month time.
+     *
+     * @return self
+     */
     public function month(int $month)
     {
         $this->time = mktime(
-      $this->hour,
-      $this->minute,
-      $this->second,
-      $month,
-      $this->day,
-      $this->year
-    );
+            $this->hour,
+            $this->minute,
+            $this->second,
+            $month,
+            $this->day,
+            $this->year
+        );
         $this->refresh();
 
         return $this;
     }
 
+    /**
+     * Set day time.
+     *
+     * @return self
+     */
     public function day(int $day)
     {
         $this->time = mktime(
-      $this->hour,
-      $this->minute,
-      $this->second,
-      $this->month,
-      $day,
-      $this->year
-    );
+            $this->hour,
+            $this->minute,
+            $this->second,
+            $this->month,
+            $day,
+            $this->year
+        );
         $this->refresh();
 
         return $this;
     }
 
+    /**
+     * Set hour time.
+     *
+     * @return self
+     */
     public function hour(int $hour)
     {
         $this->time = mktime(
-      $hour,
-      $this->minute,
-      $this->second,
-      $this->month,
-      $this->day,
-      $this->year
-    );
+            $hour,
+            $this->minute,
+            $this->second,
+            $this->month,
+            $this->day,
+            $this->year
+        );
         $this->refresh();
 
         return $this;
     }
 
+    /**
+     * Set minute time.
+     *
+     * @return self
+     */
     public function minute(int $minute)
     {
         $this->time = mktime(
-      $this->hour,
-      $minute,
-      $this->second,
-      $this->month,
-      $this->day,
-      $this->year
-    );
+            $this->hour,
+            $minute,
+            $this->second,
+            $this->month,
+            $this->day,
+            $this->year
+        );
         $this->refresh();
 
         return $this;
     }
 
+    /**
+     * Set second time.
+     *
+     * @return self
+     */
     public function second(int $second)
     {
         $this->time = mktime(
-      $this->hour,
-      $this->minute,
-      $second,
-      $this->month,
-      $this->day,
-      $this->year
-    );
+            $this->hour,
+            $this->minute,
+            $second,
+            $this->month,
+            $this->day,
+            $this->year
+        );
         $this->refresh();
 
         return $this;
@@ -148,79 +248,79 @@ class Now
 
     public function isJan(): bool
     {
-        return date('M', $this->time) == 'Jan';
+        return date('M', $this->time) === 'Jan';
     }
 
     public function isFeb(): bool
     {
-        return date('M', $this->time) == 'Feb';
+        return date('M', $this->time) === 'Feb';
     }
 
     public function isMar(): bool
     {
-        return date('M', $this->time) == 'Mar';
+        return date('M', $this->time) === 'Mar';
     }
 
     public function isApr(): bool
     {
-        return date('M', $this->time) == 'Apr';
+        return date('M', $this->time) === 'Apr';
     }
 
     public function isMay(): bool
     {
-        return date('M', $this->time) == 'May';
+        return date('M', $this->time) === 'May';
     }
 
     public function isJun(): bool
     {
-        return date('M', $this->time) == 'Jun';
+        return date('M', $this->time) === 'Jun';
     }
 
     public function isJul(): bool
     {
-        return date('M', $this->time) == 'Jul';
+        return date('M', $this->time) === 'Jul';
     }
 
     public function isAug(): bool
     {
-        return date('M', $this->time) == 'Aug';
+        return date('M', $this->time) === 'Aug';
     }
 
     public function isSep(): bool
     {
-        return date('M', $this->time) == 'Sep';
+        return date('M', $this->time) === 'Sep';
     }
 
     public function isOct(): bool
     {
-        return date('M', $this->time) == 'Oct';
+        return date('M', $this->time) === 'Oct';
     }
 
     public function isNov(): bool
     {
-        return date('M', $this->time) == 'Nov';
+        return date('M', $this->time) === 'Nov';
     }
 
     //  day
 
     public function isDec(): bool
     {
-        return date('M', $this->time) == 'Dec';
+        return date('M', $this->time) === 'Dec';
     }
 
     public function isMonday(): bool
     {
-        return date('D', $this->time) == 'Mon';
+        return date('D', $this->time) === 'Mon';
     }
 
     public function isTuesday(): bool
     {
-        return date('D', $this->time) == 'Tue';
+        return date('D', $this->time) === 'Tue';
     }
 
     public function isWednesday(): bool
     {
-        return date('D', $this->time) == 'Wed';
+        return date('D', $this->time) === 'Wed';
     }
 
     public function isThursday(): bool

--- a/src/System/Time/helper.php
+++ b/src/System/Time/helper.php
@@ -5,6 +5,8 @@ if (!function_exists('now')) {
      * Get time object class.
      *
      * @param string $date_format Set current time
+     *
+     * @return \System\Time\Now
      */
     function now(string $date_format = 'now')
     {

--- a/tests/Time/HelperFuctionTest.php
+++ b/tests/Time/HelperFuctionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-final class HelperFunctionTest extends TestCase
+final class HelperFuctionTest extends TestCase
 {
     /**
      * @test

--- a/tests/Time/TimeTravelTest.php
+++ b/tests/Time/TimeTravelTest.php
@@ -13,10 +13,11 @@ final class TimeTravelTest extends TestCase
         $now = new Now();
 
         $this->assertEquals(
-      time(),
-      $now->timestamp,
-      'timestamp must equal'
-    );
+            time(),
+            $now->timestamp,
+            'timestamp must equal'
+        );
+        $now->age;
 
         $this->assertEquals(
       date('Y'),
@@ -146,5 +147,23 @@ final class TimeTravelTest extends TestCase
       $now->age,
       'the age must equal'
     );
+    }
+
+    /** @test */
+    public function itCanGetFromPrivateProperty()
+    {
+        $now = new Now();
+        $now->day(12);
+
+        $this->assertEquals(12, $now->day);
+    }
+
+    /** @test */
+    public function itCanSetFromProperty()
+    {
+        $now      = new Now();
+        $now->day = 12;
+
+        $this->assertEquals(12, $now->day);
     }
 }


### PR DESCRIPTION
Refactor property to prevent over-lab without refresh class. When use public input can bypass property and make class not sync with `Time::timestamp`.
