### PR TITLE
0.9

### DIFF
--- a/src/System/Database/MyCRUD.php
+++ b/src/System/Database/MyCRUD.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database;
 
 use System\Collection\Collection;
@@ -8,26 +10,40 @@ use System\Database\MyQuery\Join\InnerJoin;
 
 abstract class MyCRUD
 {
-    /** @var MyPDO|null */
-    protected $PDO = null;
+    /** @var MyPDO */
+    protected $PDO;
+
     /** @var string */
     protected $TABLE_NAME;
-    /** @var array */
+
+    /** @var array<string, mixed> */
     protected $COLUMNS = [];
+
     /** @var string */
     protected $PRIMERY_KEY = 'id';
+
     /** @var string|int */
     protected $IDENTIFER = '';
-    /** @var array set Column cant be modify */
+
+    /** @var string[] set Column cant be modify */
     protected $RESISTANT;
-    /** @var array orginal data from database */
+
+    /** @var array<string, mixed> orginal data from database */
     protected $FRESH;
 
+    /**
+     * @return string|int
+     */
     public function getID()
     {
         return $this->IDENTIFER;
     }
 
+    /**
+     * @param string|int $val
+     *
+     * @return self
+     */
     public function setID($val)
     {
         $this->IDENTIFER = $val;
@@ -35,6 +51,13 @@ abstract class MyCRUD
         return $this;
     }
 
+    /**
+     * Setter.
+     *
+     * @param mixed $val
+     *
+     * @return self
+     */
     protected function setter(string $key, $val)
     {
         if (key_exists($key, $this->COLUMNS) && !isset($this->RESISTANT[$key])) {
@@ -44,19 +67,42 @@ abstract class MyCRUD
         return $this;
     }
 
+    /**
+     * Getter.
+     *
+     * @param string     $key
+     * @param mixed|null $defaul
+     *
+     * @return mixed
+     */
     protected function getter($key, $defaul = null)
     {
         return $this->COLUMNS[$key] ?? $defaul;
     }
 
+    /**
+     * Getter.
+     *
+     * @param string $name
+     *
+     * @return mixed
+     */
     public function __get($name)
     {
         return $this->getter($name);
     }
 
+    /**
+     * Setter.
+     *
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @return self
+     */
     public function __set($name, $value)
     {
-        $this->setter($name, $value);
+        return $this->setter($name, $value);
     }
 
     public function read(): bool
@@ -140,6 +186,13 @@ abstract class MyCRUD
         return $id === false ? '' : $id;
     }
 
+    /**
+     * Convert array to class property.
+     *
+     * @param array<string, mixed> $arr_column
+     *
+     * @return self
+     */
     public function convertFromArray(array $arr_column)
     {
         foreach ($arr_column as $key => $value) {
@@ -149,6 +202,11 @@ abstract class MyCRUD
         return $this;
     }
 
+    /**
+     * Convert class property to array.
+     *
+     * @return array<string, mixed>
+     */
     public function convertToArray(): array
     {
         return $this->COLUMNS;
@@ -159,7 +217,10 @@ abstract class MyCRUD
         return new Collection($this->COLUMNS);
     }
 
-    protected function column_names(): array
+    /**
+     * @return string[]
+     */
+    protected function column_names()
     {
         $table_info = MyQuery::from($this->TABLE_NAME, $this->PDO)
             ->info()
@@ -168,11 +229,17 @@ abstract class MyCRUD
         return array_values(array_column($table_info, 'COLUMN_NAME'));
     }
 
+    /**
+     * @param string $name Column name
+     */
     public function __isset($name)
     {
         return isset($this->COLUMNS[$name]);
     }
 
+    /**
+     * @return CollectionImmutable
+     */
     protected function hasOne(string $table, string $ref = 'id')
     {
         $ref = MyQuery::from($this->TABLE_NAME, $this->PDO)
@@ -186,6 +253,9 @@ abstract class MyCRUD
         return new CollectionImmutable($ref);
     }
 
+    /**
+     * @return CollectionImmutable
+     */
     protected function hasMany(string $table, string $ref = 'id')
     {
         $ref = MyQuery::from($this->TABLE_NAME, $this->PDO)

--- a/src/System/Database/MyPDO.php
+++ b/src/System/Database/MyPDO.php
@@ -20,6 +20,9 @@ class MyPDO
      */
     private $configs;
 
+    /**
+     * @param array<string, string> $configs
+     */
     public function __construct(array $configs)
     {
         $database_name    = $configs['database_name'];
@@ -47,7 +50,13 @@ class MyPDO
         static::$Instance = $this;
     }
 
-    /** Create connaction using static */
+    /**
+     * Create connaction using static.
+     *
+     * @param array<string, string> $configs
+     *
+     * @return MyPDO
+     * */
     public static function conn(array $configs)
     {
         return new self($configs);
@@ -87,7 +96,11 @@ class MyPDO
     }
 
     /**
-     * menggantikan paramater input dari user dengan sebuah placeholder.
+     * Menggantikan paramater input dari user dengan sebuah placeholder.
+     *
+     * @param int|string $param
+     * @param mixed      $value
+     * @param int|null   $type
      */
     public function bind($param, $value, $type = null): self
     {
@@ -128,6 +141,8 @@ class MyPDO
 
     /**
      * mengembalikan hasil dari query yang dijalankan berupa array.
+     *
+     * @return mixed[]|false
      */
     public function resultset()
     {
@@ -137,7 +152,9 @@ class MyPDO
     }
 
     /**
-     * mengembalikan hasil dari query, ditampilkan hanya satu baris data saja.
+     * Mengembalikan hasil dari query, ditampilkan hanya satu baris data saja.
+     *
+     * @return mixed
      */
     public function single()
     {
@@ -166,6 +183,9 @@ class MyPDO
         return $this->dbh->lastInsertId();
     }
 
+    /**
+     * @return bool Transaction status
+     */
     public function transaction(callable $callable)
     {
         if (false === $this->beginTransaction()) {

--- a/src/System/Database/MyPDO.php
+++ b/src/System/Database/MyPDO.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database;
 
 use Exception;
@@ -48,6 +50,16 @@ class MyPDO
 
         // set instance @phpstan-ignore-next-line
         static::$Instance = $this;
+    }
+
+    /**
+     * Singleton pattern implemnt for Databese connation.
+     *
+     * @return self
+     */
+    public function instance()
+    {
+        return $this;
     }
 
     /**

--- a/src/System/Database/MyPDO.php
+++ b/src/System/Database/MyPDO.php
@@ -79,6 +79,8 @@ class MyPDO
      * Singleton pattern implemnt for Databese connation.
      *
      * @return MyPDO MyPDO with singleton
+     *
+     * @deprecated
      */
     public static function getInstance(): self
     {

--- a/src/System/Database/MyQuery.php
+++ b/src/System/Database/MyQuery.php
@@ -14,16 +14,16 @@ class MyQuery
     public const ORDER_ASC   = 0;
     public const ORDER_DESC  = 1;
     /** @var MyPDO */
-    protected $PDO    = null;
+    protected $PDO;
 
     /**
      * Create new Builder.
      *
-     * @param MyPDO $PDO The PDO connection, null give global instance
+     * @param MyPDO $PDO the PDO connection
      */
-    public function __construct(MyPDO $PDO = null)
+    public function __construct(MyPDO $PDO)
     {
-        $this->PDO = $PDO ?? MyPDO::getInstance();
+        $this->PDO = $PDO;
     }
 
     /**
@@ -58,7 +58,7 @@ class MyQuery
      *
      * @return Table
      */
-    public static function from(string $table_name, MyPDO $PDO = null)
+    public static function from(string $table_name, MyPDO $PDO)
     {
         $conn = new MyQuery($PDO);
 

--- a/src/System/Database/MyQuery.php
+++ b/src/System/Database/MyQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database;
 
 use System\Database\MyQuery\Table;
@@ -28,6 +30,8 @@ class MyQuery
      * Create builder using invoke.
      *
      * @param string $table_name Table name
+     *
+     * @return Table
      */
     public function __invoke(string $table_name)
     {
@@ -38,6 +42,8 @@ class MyQuery
      * Create builder and set table name.
      *
      * @param string $table_name Table name
+     *
+     * @return Table
      */
     public function table(string $table_name)
     {
@@ -49,6 +55,8 @@ class MyQuery
      *
      * @param string $table_name Table name
      * @param MyPDO  $PDO        The PDO connection, null give global instance
+     *
+     * @return Table
      */
     public static function from(string $table_name, MyPDO $PDO = null)
     {

--- a/src/System/Database/MyQuery/Delete.php
+++ b/src/System/Database/MyQuery/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database\MyQuery;
 
 use System\Database\MyPDO;

--- a/src/System/Database/MyQuery/Delete.php
+++ b/src/System/Database/MyQuery/Delete.php
@@ -9,10 +9,10 @@ class Delete extends Execute
 {
     use ConditionTrait;
 
-    public function __construct(string $table_name, MyPDO $PDO = null)
+    public function __construct(string $table_name, MyPDO $PDO)
     {
         $this->_table = $table_name;
-        $this->PDO    = $PDO ?? MyPDO::getInstance();
+        $this->PDO    = $PDO;
     }
 
     public function __toString()

--- a/src/System/Database/MyQuery/Execute.php
+++ b/src/System/Database/MyQuery/Execute.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database\MyQuery;
 
 abstract class Execute extends Query

--- a/src/System/Database/MyQuery/Fetch.php
+++ b/src/System/Database/MyQuery/Fetch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database\MyQuery;
 
 use System\Collection\Collection;
@@ -11,7 +13,10 @@ abstract class Fetch extends Query
         return new Collection($this->all());
     }
 
-    public function single(): array
+    /**
+     * @return string[]|mixed
+     */
+    public function single()
     {
         $this->builder();
 
@@ -21,10 +26,11 @@ abstract class Fetch extends Query
         }
         $result = $this->PDO->single();
 
-        return $result == false ? [] : $this->PDO->single();
+        return $result === false ? [] : $this->PDO->single();
     }
 
-    public function all(): array
+    /** @return array<string|int, mixed>|false */
+    public function all()
     {
         $this->builder();
 

--- a/src/System/Database/MyQuery/Insert.php
+++ b/src/System/Database/MyQuery/Insert.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database\MyQuery;
 
 use System\Database\MyPDO;
@@ -17,6 +19,13 @@ class Insert extends Execute
         return $this->builder();
     }
 
+    /**
+     *  Value query builder (key => value).
+     *
+     * @param array<string, string> $values Insert values
+     *
+     * @return self
+     */
     public function values(array $values)
     {
         foreach ($values as $key => $value) {
@@ -26,6 +35,9 @@ class Insert extends Execute
         return $this;
     }
 
+    /**
+     * @return self
+     */
     public function value(string $bind, string $value)
     {
         $this->_binder[] = [$bind, $value, true];
@@ -37,9 +49,9 @@ class Insert extends Execute
     {
         $arraycolumns = array_column($this->_binder, 0);
         $arrayBinds   = array_map(
-      fn ($e) => ":val_$e",
-      array_column($this->_binder, 0)
-    );
+            fn ($e) => ":val_$e",
+            array_column($this->_binder, 0)
+        );
         $arraycolumns = array_filter($arraycolumns);
         $arrayBinds   = array_filter($arrayBinds);
 

--- a/src/System/Database/MyQuery/Insert.php
+++ b/src/System/Database/MyQuery/Insert.php
@@ -8,10 +8,10 @@ use System\Database\MyPDO;
 
 class Insert extends Execute
 {
-    public function __construct(string $table_name, MyPDO $PDO = null)
+    public function __construct(string $table_name, MyPDO $PDO)
     {
         $this->_table = $table_name;
-        $this->PDO    = $PDO ?? MyPDO::getInstance();
+        $this->PDO    = $PDO;
     }
 
     public function __toString()

--- a/src/System/Database/MyQuery/Insert.php
+++ b/src/System/Database/MyQuery/Insert.php
@@ -22,11 +22,11 @@ class Insert extends Execute
     /**
      *  Value query builder (key => value).
      *
-     * @param array<string, string> $values Insert values
+     * @param array<string, string|int|bool|null> $values Insert values
      *
      * @return self
      */
-    public function values(array $values)
+    public function values($values)
     {
         foreach ($values as $key => $value) {
             $this->_binder[] = [$key, $value, true];
@@ -36,9 +36,11 @@ class Insert extends Execute
     }
 
     /**
+     * @param string|int|bool|null $value
+     *
      * @return self
      */
-    public function value(string $bind, string $value)
+    public function value(string $bind, $value)
     {
         $this->_binder[] = [$bind, $value, true];
 

--- a/src/System/Database/MyQuery/Join/AbstractJoin.php
+++ b/src/System/Database/MyQuery/Join/AbstractJoin.php
@@ -1,15 +1,39 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database\MyQuery\Join;
 
 abstract class AbstractJoin
 {
+    /**
+     * @var string
+     */
     protected $_mainTable     = '';
+
+    /**
+     * @var string
+     */
     protected $_tableName     = '';
+
+    /**
+     * @var string
+     */
     protected $_colomnName    = '';
+
+    /**
+     * @var string[]
+     */
     protected $_compereColumn = [];
+
+    /**
+     * @var string
+     */
     protected $_stringJoin    = '';
 
+    /**
+     * @return self
+     */
     public function __invoke(string $main_table)
     {
         $this->_mainTable = $main_table;
@@ -28,6 +52,8 @@ abstract class AbstractJoin
      * @param string      $ref_table Name of the table want to join
      * @param string      $id        Main id of the table
      * @param string|null $ref_id    Id of the table want to join, null mean same with main id
+     *
+     * @return AbstractJoin
      */
     public static function ref(string $ref_table, string $id, ?string $ref_id = null)
     {
@@ -43,6 +69,8 @@ abstract class AbstractJoin
      * set main table / master table.
      *
      * @param string $main_table Name of the master table
+     *
+     * @return self
      */
     public function table(string $main_table)
     {
@@ -55,6 +83,8 @@ abstract class AbstractJoin
      * Set table reference.
      *
      * @param string $ref_table Name of the ref table
+     *
+     * @return self
      */
     public function tableRef(string $ref_table)
     {
@@ -68,6 +98,8 @@ abstract class AbstractJoin
      *
      * @param string $main_table Name of the master table
      * @param string $ref_table  Name of the ref table
+     *
+     * @return self
      */
     public function tableRelation(string $main_table, string $ref_table)
     {
@@ -82,14 +114,16 @@ abstract class AbstractJoin
      *
      * @param string $main_column    Identical of the main table column
      * @param string $compire_column Identical of the ref table column
+     *
+     * @return self
      */
     public function compare(string $main_column, string $compire_column = null)
     {
         $compire_column = $compire_column ?? $main_column;
 
         $this->_compereColumn[] = [
-      $main_column, $compire_column,
-    ];
+            $main_column, $compire_column,
+        ];
 
         return $this;
     }

--- a/src/System/Database/MyQuery/Join/CrossJoin.php
+++ b/src/System/Database/MyQuery/Join/CrossJoin.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace System\Database\MyQuery\Join;
+
+class CrossJoin extends AbstractJoin
+{
+    /**
+     * Create cross join table query.
+     */
+    protected function joinBuilder(): string
+    {
+        return "CROSS JOIN $this->_tableName";
+    }
+}

--- a/src/System/Database/MyQuery/Query.php
+++ b/src/System/Database/MyQuery/Query.php
@@ -104,9 +104,9 @@ abstract class Query
      * Where statment setter,
      * menambahakan syarat pada query builder.
      *
-     * @param string     $bind        Key atau nama column
-     * @param string     $comparation tanda hubung yang akan digunakan (AND|OR|>|<|=|LIKE)
-     * @param string|int $value       Value atau nilai dari key atau nama column
+     * @param string               $bind        Key atau nama column
+     * @param string               $comparation tanda hubung yang akan digunakan (AND|OR|>|<|=|LIKE)
+     * @param string|int|bool|null $value       Value atau nilai dari key atau nama column
      *
      * @return self
      */

--- a/src/System/Database/MyQuery/Query.php
+++ b/src/System/Database/MyQuery/Query.php
@@ -104,13 +104,13 @@ abstract class Query
      * Where statment setter,
      * menambahakan syarat pada query builder.
      *
-     * @param string $bind        Key atau nama column
-     * @param string $comparation tanda hubung yang akan digunakan (AND|OR|>|<|=|LIKE)
-     * @param string $value       Value atau nilai dari key atau nama column
+     * @param string     $bind        Key atau nama column
+     * @param string     $comparation tanda hubung yang akan digunakan (AND|OR|>|<|=|LIKE)
+     * @param string|int $value       Value atau nilai dari key atau nama column
      *
      * @return self
      */
-    public function compare(string $bind, string $comparation, string $value, bool $bindValue = false)
+    public function compare(string $bind, string $comparation, $value, bool $bindValue = false)
     {
         $this->_binder[]       = [$bind, $value];
         $this->_filters[$bind] = [

--- a/src/System/Database/MyQuery/Select.php
+++ b/src/System/Database/MyQuery/Select.php
@@ -97,13 +97,13 @@ final class Select extends Fetch
     /**
      * Set data start for feact all data.
      *
-     * @param int $val limit start default is 0
+     * @param int $value limit start default is 0
      *
      * @return self
      */
-    public function limitStart(int $val)
+    public function limitStart(int $value)
     {
-        $this->_limit_start = $val;
+        $this->_limit_start = $value;
 
         return $this;
     }
@@ -112,13 +112,13 @@ final class Select extends Fetch
      * Set data end for feact all data
      * zero value meaning no data show.
      *
-     * @param int $val limit start default
+     * @param int $value limit start default
      *
      * @return self
      */
-    public function limitEnd(int $val)
+    public function limitEnd(int $value)
     {
-        $this->_limit_end = $val;
+        $this->_limit_end = $value;
 
         return $this;
     }

--- a/src/System/Database/MyQuery/Select.php
+++ b/src/System/Database/MyQuery/Select.php
@@ -21,11 +21,11 @@ final class Select extends Fetch
      *
      * @return void
      */
-    public function __construct(string $table_name, array $columns_name, MyPDO $PDO = null, array $options = null)
+    public function __construct(string $table_name, array $columns_name, MyPDO $PDO, array $options = null)
     {
         $this->_table  = $table_name;
         $this->_column = $columns_name;
-        $this->PDO     = $PDO ?? MyPDO::getInstance();
+        $this->PDO     = $PDO;
 
         // defaul query
         if (count($this->_column) > 1) {
@@ -46,12 +46,13 @@ final class Select extends Fetch
      *
      * @param string   $table_name  Table name
      * @param string[] $column_name Selected column
+     * @param MyPDO    $PDO         MyPdo
      *
      * @return Select
      */
-    public static function from(string $table_name, array $column_name = ['*'])
+    public static function from(string $table_name, array $column_name, MyPDO $PDO)
     {
-        return new static($table_name, $column_name);
+        return new static($table_name, $column_name, $PDO);
     }
 
     /**

--- a/src/System/Database/MyQuery/Select.php
+++ b/src/System/Database/MyQuery/Select.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database\MyQuery;
 
 use System\Database\MyPDO;
@@ -11,6 +13,14 @@ final class Select extends Fetch
 {
     use ConditionTrait;
 
+    /**
+     * @param string   $table_name   Table name
+     * @param string[] $columns_name Selected cloumn
+     * @param MyPDO    $PDO          MyPDO class
+     * @param string[] $options      Add costume option (eg: query)
+     *
+     * @return void
+     */
     public function __construct(string $table_name, array $columns_name, MyPDO $PDO = null, array $options = null)
     {
         $this->_table  = $table_name;
@@ -31,6 +41,14 @@ final class Select extends Fetch
         return $this->builder();
     }
 
+    /**
+     * Instance of `Select::class`.
+     *
+     * @param string   $table_name  Table name
+     * @param string[] $column_name Selected column
+     *
+     * @return Select
+     */
     public static function from(string $table_name, array $column_name = ['*'])
     {
         return new static($table_name, $column_name);
@@ -44,6 +62,8 @@ final class Select extends Fetch
      *  - full join.
      *
      * @param AbstractJoin $ref_table Configure type of join
+     *
+     * @return self
      */
     public function join(AbstractJoin $ref_table)
     {
@@ -62,6 +82,8 @@ final class Select extends Fetch
      *
      * @param int $limit_start limit start
      * @param int $limit_end   limit end
+     *
+     * @return self
      */
     public function limit(int $limit_start, int $limit_end)
     {
@@ -75,6 +97,8 @@ final class Select extends Fetch
      * Set data start for feact all data.
      *
      * @param int $val limit start default is 0
+     *
+     * @return self
      */
     public function limitStart(int $val)
     {
@@ -88,6 +112,8 @@ final class Select extends Fetch
      * zero value meaning no data show.
      *
      * @param int $val limit start default
+     *
+     * @return self
      */
     public function limitEnd(int $val)
     {
@@ -99,6 +125,8 @@ final class Select extends Fetch
     /**
      * Set sort column and order
      * column name must register.
+     *
+     * @return self
      */
     public function order(string $column_name, int $order_using = MyQuery::ORDER_ASC, string $belong_to = null)
     {
@@ -116,6 +144,8 @@ final class Select extends Fetch
      * False = operator using OR
      *
      * @param bool $value True where statment operation using AND
+     *
+     * @return self
      */
     public function strictMode(bool $value)
     {
@@ -133,29 +163,28 @@ final class Select extends Fetch
 
         // join
         $join = count($this->_join) == 0
-      ? ''
-      : implode(' ', $this->_join)
-    ;
+            ? ''
+            : implode(' ', $this->_join);
+
         // where
         $where  = $this->getWhere();
         $where  = $where == '' && count($this->_join) > 0
-      ? ''
-      : $where
-    ;
+            ? ''
+            : $where;
+
         // sort order
         $sort_order = $this->_sort_order == ''
-      ? ''
-      : " $this->_sort_order"
-    ;
+            ? ''
+            : " $this->_sort_order";
+
         // limit
         $limit = $this->_limit_start < 0
-      ? " LIMIT $this->_limit_end"
-      : " LIMIT $this->_limit_start, $this->_limit_end"
-    ;
+            ? " LIMIT $this->_limit_end"
+            : " LIMIT $this->_limit_start, $this->_limit_end";
+
         $limit = $this->_limit_end == 0
-      ? ''
-      : $limit
-    ;
+            ? ''
+            : $limit;
 
         $condition = $join . $where . $sort_order . $limit;
 

--- a/src/System/Database/MyQuery/Table.php
+++ b/src/System/Database/MyQuery/Table.php
@@ -22,10 +22,10 @@ class Table
      */
     protected $table_name;
 
-    public function __construct(string $table_name, MyPDO $PDO = null)
+    public function __construct(string $table_name, MyPDO $PDO)
     {
         $this->table_name = $table_name;
-        $this->PDO        = $PDO ?? MyPDO::getInstance();
+        $this->PDO        = $PDO;
     }
 
     /**

--- a/src/System/Database/MyQuery/Table.php
+++ b/src/System/Database/MyQuery/Table.php
@@ -1,12 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database\MyQuery;
 
 use System\Database\MyPDO;
 
 class Table
 {
-    protected $PDO = null;
+    /**
+     * MyPDO instance.
+     *
+     * @var MyPDO
+     */
+    protected $PDO;
+
+    /**
+     * Table name.
+     *
+     * @var string
+     */
     protected $table_name;
 
     public function __construct(string $table_name, MyPDO $PDO = null)
@@ -15,53 +28,74 @@ class Table
         $this->PDO        = $PDO ?? MyPDO::getInstance();
     }
 
+    /**
+     * Perform select query.
+     *
+     * @return Insert
+     */
     public function insert()
     {
-        $newQuery = new Insert($this->table_name, $this->PDO);
-
-        return $newQuery;
+        return new Insert($this->table_name, $this->PDO);
     }
 
+    /**
+     * Perform select query.
+     *
+     * @param string[] $select_columns Selected column (raw)
+     *
+     * @return Select
+     */
     public function select(array $select_columns = ['*'])
     {
-        $newQuery = new Select($this->table_name, $select_columns, $this->PDO);
-
-        return $newQuery;
+        return new Select($this->table_name, $select_columns, $this->PDO);
     }
 
+    /**
+     * Perform update query.
+     *
+     * @return Update
+     */
     public function update()
     {
-        $newQuery = new Update($this->table_name, $this->PDO);
-
-        return $newQuery;
+        return new Update($this->table_name, $this->PDO);
     }
 
+    /**
+     * Perform delete query.
+     *
+     * @return Delete
+     */
     public function delete()
     {
-        $newQuery = new Delete($this->table_name, $this->PDO);
-
-        return $newQuery;
+        return new Delete($this->table_name, $this->PDO);
     }
 
+    /**
+     * Get table information.
+     *
+     * @return array<string, mixed>
+     */
     public function info(): array
     {
         $this->PDO->query(
-      'SELECT
-        `COLUMN_NAME`,
-        `COLUMN_TYPE`,
-        `CHARACTER_SET_NAME`,
-        `COLLATION_NAME`,
-        `IS_NULLABLE`,
-        `ORDINAL_POSITION`,
-        `COLUMN_KEY`
-      FROM
-        INFORMATION_SCHEMA.COLUMNS
-      WHERE
-        TABLE_SCHEMA = :dbs AND TABLE_NAME = :table'
-    );
+            'SELECT
+                `COLUMN_NAME`,
+                `COLUMN_TYPE`,
+                `CHARACTER_SET_NAME`,
+                `COLLATION_NAME`,
+                `IS_NULLABLE`,
+                `ORDINAL_POSITION`,
+                `COLUMN_KEY`
+            FROM
+                INFORMATION_SCHEMA.COLUMNS
+            WHERE
+                TABLE_SCHEMA = :dbs AND TABLE_NAME = :table'
+        );
         $this->PDO->bind(':table', $this->table_name);
         $this->PDO->bind(':dbs', $this->PDO->configs()['database_name']);
 
-        return $this->PDO->resultset() ?? [];
+        $result = $this->PDO->resultset();
+
+        return $result === false ? [] : $result;
     }
 }

--- a/src/System/Database/MyQuery/Traits/ConditionTrait.php
+++ b/src/System/Database/MyQuery/Traits/ConditionTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database\MyQuery\Traits;
 
 use System\Database\MyQuery\Select;
@@ -9,6 +11,14 @@ use System\Database\MyQuery\Select;
  */
 trait ConditionTrait
 {
+    /**
+     * Insert 'equal' condition in (query bulider).
+     *
+     * @param string $bind  Bind
+     * @param string $value Value of bind
+     *
+     * @return self
+     */
     public function equal(string $bind, string $value)
     {
         $this->compare($bind, '=', $value, false);
@@ -16,6 +26,14 @@ trait ConditionTrait
         return $this;
     }
 
+    /**
+     * Insert 'like' condition in (query bulider).
+     *
+     * @param string $bind  Bind
+     * @param string $value Value of bind
+     *
+     * @return self
+     */
     public function like(string $bind, string $value)
     {
         $this->compare($bind, 'LIKE', $value, false);
@@ -23,30 +41,55 @@ trait ConditionTrait
         return $this;
     }
 
+    /**
+     * Insert 'where' condition in (query bulider).
+     *
+     * @param string                         $where_condition Spesific column name
+     * @param array<int, array<int, string>> $binder          Bind and value (use for 'in')
+     *
+     * @return self
+     */
     public function where(string $where_condition, ?array $binder = null)
     {
         $this->_where[] = $where_condition;
 
-        if ($binder != null) {
+        if ($binder !== null) {
             $this->_binder = array_merge($this->_binder, $binder);
         }
 
         return $this;
     }
 
+    /**
+     * Insert 'between' condition in (query bulider).
+     *
+     * @param string $column_name Spesific column name
+     * @param string $val_1       Between
+     * @param string $val_2       Between
+     *
+     * @return self
+     */
     public function between(string $column_name, string $val_1, string $val_2)
     {
         $this->where(
-      "(`$this->_table`.`$column_name` BETWEEN :b_start AND :b_end)",
-      [
-        [':b_start', $val_1],
-        [':b_end', $val_2],
-      ]
-    );
+            "(`$this->_table`.`$column_name` BETWEEN :b_start AND :b_end)",
+            [
+                [':b_start', $val_1],
+                [':b_end', $val_2],
+            ]
+        );
 
         return $this;
     }
 
+    /**
+     * Insert 'in' condition (query bulider).
+     *
+     * @param string   $column_name Spesific column name
+     * @param string[] $val         Bind and value (use for 'in')
+     *
+     * @return self
+     */
     public function in(string $column_name, array $val)
     {
         $binds  = [];
@@ -58,13 +101,20 @@ trait ConditionTrait
         $bindString = implode(', ', $binds);
 
         $this->where(
-      "(`$this->_table`.`$column_name` IN ($bindString))",
-      $binder
-    );
+            "(`$this->_table`.`$column_name` IN ($bindString))",
+            $binder
+        );
 
         return $this;
     }
 
+    /**
+     * Insert 'where exists' condition (query bulider).
+     *
+     * @param Select $select Select class
+     *
+     * @return self
+     */
     public function whereExist(Select $select)
     {
         $this->_where[] = 'EXISTS (' . $select->__toString() . ')';
@@ -73,6 +123,13 @@ trait ConditionTrait
         return $this;
     }
 
+    /**
+     * Insert 'where not exists' condition (query bulider).
+     *
+     * @param Select $select Select class
+     *
+     * @return self
+     */
     public function whereNotExist(Select $select)
     {
         $this->_where[] = 'NOT EXISTS (' . $select->__toString() . ')';

--- a/src/System/Database/MyQuery/Traits/ConditionTrait.php
+++ b/src/System/Database/MyQuery/Traits/ConditionTrait.php
@@ -63,9 +63,9 @@ trait ConditionTrait
     /**
      * Insert 'between' condition in (query bulider).
      *
-     * @param string     $column_name Spesific column name
-     * @param string|int $value_1     Between start
-     * @param string|int $value_2     Between end
+     * @param string $column_name Spesific column name
+     * @param int    $value_1     Between start
+     * @param int    $value_2     Between end
      *
      * @return self
      */

--- a/src/System/Database/MyQuery/Traits/ConditionTrait.php
+++ b/src/System/Database/MyQuery/Traits/ConditionTrait.php
@@ -14,12 +14,12 @@ trait ConditionTrait
     /**
      * Insert 'equal' condition in (query bulider).
      *
-     * @param string $bind  Bind
-     * @param string $value Value of bind
+     * @param string               $bind  Bind
+     * @param string|int|bool|null $value Value of bind
      *
      * @return self
      */
-    public function equal(string $bind, string $value)
+    public function equal(string $bind, $value)
     {
         $this->compare($bind, '=', $value, false);
 
@@ -29,12 +29,12 @@ trait ConditionTrait
     /**
      * Insert 'like' condition in (query bulider).
      *
-     * @param string $bind  Bind
-     * @param string $value Value of bind
+     * @param string               $bind  Bind
+     * @param string|int|bool|null $value Value of bind
      *
      * @return self
      */
-    public function like(string $bind, string $value)
+    public function like(string $bind, $value)
     {
         $this->compare($bind, 'LIKE', $value, false);
 
@@ -44,8 +44,8 @@ trait ConditionTrait
     /**
      * Insert 'where' condition in (query bulider).
      *
-     * @param string                         $where_condition Spesific column name
-     * @param array<int, array<int, string>> $binder          Bind and value (use for 'in')
+     * @param string                             $where_condition Spesific column name
+     * @param array<int, array<int, string|int>> $binder          Bind and value (use for 'in')
      *
      * @return self
      */
@@ -63,19 +63,19 @@ trait ConditionTrait
     /**
      * Insert 'between' condition in (query bulider).
      *
-     * @param string $column_name Spesific column name
-     * @param string $val_1       Between
-     * @param string $val_2       Between
+     * @param string     $column_name Spesific column name
+     * @param string|int $value_1     Between start
+     * @param string|int $value_2     Between end
      *
      * @return self
      */
-    public function between(string $column_name, string $val_1, string $val_2)
+    public function between(string $column_name, $value_1, $value_2)
     {
         $this->where(
             "(`$this->_table`.`$column_name` BETWEEN :b_start AND :b_end)",
             [
-                [':b_start', $val_1],
-                [':b_end', $val_2],
+                [':b_start', $value_1],
+                [':b_end', $value_2],
             ]
         );
 
@@ -85,16 +85,16 @@ trait ConditionTrait
     /**
      * Insert 'in' condition (query bulider).
      *
-     * @param string   $column_name Spesific column name
-     * @param string[] $val         Bind and value (use for 'in')
+     * @param string                                  $column_name Spesific column name
+     * @param array<int|string, string|int|bool|null> $value       Bind and value (use for 'in')
      *
      * @return self
      */
-    public function in(string $column_name, array $val)
+    public function in(string $column_name, $value)
     {
         $binds  = [];
         $binder = [];
-        foreach ($val as $key => $bind) {
+        foreach ($value as $key => $bind) {
             $binds[]  = ":in_$key";
             $binder[] = [":in_$key", $bind];
         }

--- a/src/System/Database/MyQuery/Update.php
+++ b/src/System/Database/MyQuery/Update.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace System\Database\MyQuery;
 
 use System\Database\MyPDO;
@@ -20,6 +22,13 @@ class Update extends Execute
         return $this->builder();
     }
 
+    /**
+     * Insert set value (single).
+     *
+     * @param string[] $values Array of bing and value
+     *
+     * @return self
+     */
     public function values(array $values)
     {
         foreach ($values as $key => $value) {
@@ -29,6 +38,14 @@ class Update extends Execute
         return $this;
     }
 
+    /**
+     * Insert set value (single).
+     *
+     * @param string $bind  Pdo bind
+     * @param string $value Value of the bind
+     *
+     * @return self
+     */
     public function value(string $bind, string $value)
     {
         $this->_binder[] = [$bind, $value, true];
@@ -41,14 +58,14 @@ class Update extends Execute
         $where = $this->getWhere();
 
         $setArray = array_map(
-      fn ($e, $c) => $c == true ? "`$e` = :val_$e" : null,
-      array_column($this->_binder, 0),
-      array_column($this->_binder, 2)
-    );
+            fn ($e, $c) => $c == true ? "`$e` = :val_$e" : null,
+            array_column($this->_binder, 0),
+            array_column($this->_binder, 2)
+        );
         $setArray   = array_filter($setArray);  // remove empety items
-    $setString      = implode(', ', $setArray); // concvert to string
+        $setString  = implode(', ', $setArray); // concvert to string
 
-    $this->_query = "UPDATE `$this->_table` SET $setString $where";
+        $this->_query = "UPDATE `$this->_table` SET $setString $where";
 
         return $this->_query;
     }

--- a/src/System/Database/MyQuery/Update.php
+++ b/src/System/Database/MyQuery/Update.php
@@ -11,10 +11,10 @@ class Update extends Execute
 {
     use ConditionTrait;
 
-    public function __construct(string $table_name, MyPDO $PDO = null)
+    public function __construct(string $table_name, MyPDO $PDO)
     {
         $this->_table = $table_name;
-        $this->PDO    = $PDO ?? MyPDO::getInstance();
+        $this->PDO    = $PDO;
     }
 
     public function __toString()

--- a/src/System/Database/MyQuery/Update.php
+++ b/src/System/Database/MyQuery/Update.php
@@ -25,11 +25,11 @@ class Update extends Execute
     /**
      * Insert set value (single).
      *
-     * @param string[] $values Array of bing and value
+     * @param array<string, string|int|bool|null> $values Array of bing and value
      *
      * @return self
      */
-    public function values(array $values)
+    public function values($values)
     {
         foreach ($values as $key => $value) {
             $this->_binder[] = [$key, $value, true];
@@ -41,12 +41,12 @@ class Update extends Execute
     /**
      * Insert set value (single).
      *
-     * @param string $bind  Pdo bind
-     * @param string $value Value of the bind
+     * @param string               $bind  Pdo bind
+     * @param string|int|bool|null $value Value of the bind
      *
      * @return self
      */
-    public function value(string $bind, string $value)
+    public function value(string $bind, $value)
     {
         $this->_binder[] = [$bind, $value, true];
 

--- a/src/System/Support/Facedes/Facede.php
+++ b/src/System/Support/Facedes/Facede.php
@@ -16,11 +16,11 @@ abstract class Facede
     protected static $app;
 
     /**
-     * Accessor.
+     * Instance accessor.
      *
      * @var mixed
      */
-    protected static $accessor;
+    protected static $instance;
 
     /**
      * Set Accessor.
@@ -33,28 +33,41 @@ abstract class Facede
     }
 
     /**
-     * Set accessor from application.
+     * Get accessor from application.
      *
-     * @return void
+     * @return string|class-string
      *
      * @throws \RuntimeException
      */
-    protected static function setAccessor()
+    protected static function getAccessor()
     {
         throw new \RuntimeException('Application not found');
-        // static::$accessor = static::$app->get('class-name');
     }
 
     /**
-     * Get accessor.
+     * Faced.
      *
      * @return mixed
      */
-    protected static function getAccessor()
+    protected static function getFacede()
     {
-        static::setAccessor();
+        return static::getFacedeBase(static::getAccessor());
+    }
 
-        return static::$accessor;
+    /**
+     * Faced.
+     *
+     * @param string|class-string $name Entry name or a class name
+     *
+     * @return mixed
+     */
+    protected static function getFacedeBase(string $name)
+    {
+        if (isset(static::$instance[$name])) {
+            return static::$instance[$name];
+        }
+
+        return static::$instance[$name] = static::$app->get($name);
     }
 
     /**
@@ -69,7 +82,7 @@ abstract class Facede
      */
     public static function __callStatic($name, $arguments)
     {
-        $instance = static::getAccessor();
+        $instance = static::getFacede();
 
         if (!$instance) {
             throw new \RuntimeException('A facade root has not been set.');

--- a/src/System/Support/Facedes/Facede.php
+++ b/src/System/Support/Facedes/Facede.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace System\Support\Facedes;
+
+use System\Integrate\Application;
+
+abstract class Facede
+{
+    /**
+     * Application accessor.
+     *
+     * @var Application
+     */
+    protected static $app;
+
+    /**
+     * Accessor.
+     *
+     * @var mixed
+     */
+    protected static $accessor;
+
+    /**
+     * Set Accessor.
+     *
+     * @return void
+     */
+    public function __construct(Application $app)
+    {
+        static::$app = $app;
+    }
+
+    /**
+     * Set accessor from application.
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    protected static function setAccessor()
+    {
+        throw new \RuntimeException('Application not found');
+        // static::$accessor = static::$app->get('class-name');
+    }
+
+    /**
+     * Get accessor.
+     *
+     * @return mixed
+     */
+    protected static function getAccessor()
+    {
+        static::setAccessor();
+
+        return static::$accessor;
+    }
+
+    /**
+     * Call static from accessor.
+     *
+     * @param string            $name
+     * @param array<int, mixed> $arguments
+     *
+     * @return mixed
+     *
+     * @throws \RuntimeException
+     */
+    public static function __callStatic($name, $arguments)
+    {
+        $instance = static::getAccessor();
+
+        if (!$instance) {
+            throw new \RuntimeException('A facade root has not been set.');
+        }
+
+        return $instance->$name(...$arguments);
+    }
+}

--- a/tests/DataBase/QueryStringTest.php
+++ b/tests/DataBase/QueryStringTest.php
@@ -3,6 +3,7 @@
 use PHPUnit\Framework\TestCase;
 use System\Database\MyPDO;
 use System\Database\MyQuery;
+use System\Database\MyQuery\Join\CrossJoin;
 use System\Database\MyQuery\Join\FullJoin;
 use System\Database\MyQuery\Join\InnerJoin;
 use System\Database\MyQuery\Join\LeftJoin;
@@ -31,145 +32,135 @@ final class QueryStringTest extends TestCase
         // tester
 
         $select['between'] = MyQuery::from('test', $this->PDO)
-      ->select()
-      ->between('column_1', 1, 100)
-    ;
+            ->select()
+            ->between('column_1', 1, 100);
 
         $select['compare'] = MyQuery::from('test', $this->PDO)
-      ->select()
-      ->between('column_1', 1, 100)
-    ;
+            ->select()
+            ->between('column_1', 1, 100);
 
         $select['equal'] = MyQuery::from('test', $this->PDO)
-      ->select()
-      ->equal('column_1', 'test')
-    ;
+            ->select()
+            ->equal('column_1', 'test');
 
         $select['in'] = MyQuery::from('test', $this->PDO)
-      ->select()
-      ->in('column_1', [1, 2, 3, 4])
-    ;
+            ->select()
+            ->in('column_1', [1, 2, 3, 4]);
 
         $select['like'] = MyQuery::from('test', $this->PDO, $this->PDO)
-      ->select()
-      ->like('column_1', 'test')
-    ;
+            ->select()
+            ->like('column_1', 'test');
 
         $select['where'] = MyQuery::from('test', $this->PDO, $this->PDO)
-      ->select()
-      ->where('a < :a OR b > :b', ['a' => 1, 'b' => 2])
-    ;
+            ->select()
+            ->where('a < :a OR b > :b', ['a' => 1, 'b' => 2]);
 
         // assertation
 
         $this->assertEquals(
-      'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end)',
-      $select['between'],
-      'select with where statment is between'
-    );
+            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end)',
+            $select['between'],
+            'select with where statment is between'
+        );
 
         $this->assertEquals(
-      'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end)',
-      $select['compare'],
-      'select with where statment is compare'
-    );
+            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end)',
+            $select['compare'],
+            'select with where statment is compare'
+        );
 
         $this->assertEquals(
-      'SELECT * FROM `test` WHERE (`test`.`column_1` IN (:in_0, :in_1, :in_2, :in_3))',
-      $select['in'],
-      'select with where statment is in'
-    );
+            'SELECT * FROM `test` WHERE (`test`.`column_1` IN (:in_0, :in_1, :in_2, :in_3))',
+            $select['in'],
+            'select with where statment is in'
+        );
 
         $this->assertEquals(
-      'SELECT * FROM `test` WHERE ( (test.column_1 = :column_1) )',
-      $select['equal'],
-      'select with where statment is equal'
-    );
+            'SELECT * FROM `test` WHERE ( (test.column_1 = :column_1) )',
+            $select['equal'],
+            'select with where statment is equal'
+        );
 
         $this->assertEquals(
-      'SELECT * FROM `test` WHERE ( (test.column_1 LIKE :column_1) )',
-      $select['like'],
-      'select with where statment is like'
-    );
+            'SELECT * FROM `test` WHERE ( (test.column_1 LIKE :column_1) )',
+            $select['like'],
+            'select with where statment is like'
+        );
 
         $this->assertEquals(
-      'SELECT * FROM `test` WHERE a < :a OR b > :b',
-      $select['where'],
-      'select with where statment is like'
-    );
+            'SELECT * FROM `test` WHERE a < :a OR b > :b',
+            $select['where'],
+            'select with where statment is like'
+        );
     }
 
     /** @test */
     public function itCorrectSelectQueryAndLimitOrder(): void
     {
         $select = MyQuery::from('test', $this->PDO)
-      ->select()
-      ->between('column_1', 1, 100)
-      ->limit(1, 10)
-      ->order('column_1', MyQuery::ORDER_ASC)
-    ;
+            ->select()
+            ->between('column_1', 1, 100)
+            ->limit(1, 10)
+            ->order('column_1', MyQuery::ORDER_ASC);
 
         $this->assertEquals(
-      'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end) ORDER BY `test`.`column_1` ASC LIMIT 1, 10',
-      $select,
-      'select with where statment is between'
-    );
+            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end) ORDER BY `test`.`column_1` ASC LIMIT 1, 10',
+            $select,
+            'select with where statment is between'
+        );
     }
 
     /** @test */
     public function itCorrectSelectMultyColumn(): void
     {
         $select = MyQuery::from('test', $this->PDO)
-      ->select(['column_1', 'column_2', 'column_3'])
-      ->equal('column_1', 123)
-      ->equal('column_2', 'abc')
-      ->equal('column_3', true)
-    ;
+            ->select(['column_1', 'column_2', 'column_3'])
+            ->equal('column_1', 123)
+            ->equal('column_2', 'abc')
+            ->equal('column_3', true);
 
         $this->assertEquals(
-      'SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = :column_1) AND (test.column_2 = :column_2) AND (test.column_3 = :column_3) )',
-      $select,
-      'select statment must have 3 selected query'
-    );
+            'SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = :column_1) AND (test.column_2 = :column_2) AND (test.column_3 = :column_3) )',
+            $select,
+            'select statment must have 3 selected query'
+        );
     }
 
     /** @test */
     public function itCorrectSelectUsingOrStatment(): void
     {
         $select = MyQuery::from('test', $this->PDO)
-      ->select(['column_1', 'column_2', 'column_3'])
-      ->equal('column_1', 123)
-      ->equal('column_2', 'abc')
-      ->strictMode(false)
-    ;
+            ->select(['column_1', 'column_2', 'column_3'])
+            ->equal('column_1', 123)
+            ->equal('column_2', 'abc')
+            ->strictMode(false);
 
         $this->assertEquals(
-      'SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = :column_1) OR (test.column_2 = :column_2) )',
-      $select,
-      'select statment must have using or statment'
-    );
+            'SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = :column_1) OR (test.column_2 = :column_2) )',
+            $select,
+            'select statment must have using or statment'
+        );
     }
 
     /** @test */
     public function itCorrectInsertQueryMultyValues(): void
     {
         $insert = MyQuery::from('test', $this->PDO)
-      ->insert()
-      // insert using multy value
-      ->values([
-        'a' => 'b',
-        'c' => 'd',
-        'e' => 'f',
-      ])
-      // insert using single value
-      ->value('g', 'h')
-    ;
+            ->insert()
+            // insert using multy value
+            ->values([
+                'a' => 'b',
+                'c' => 'd',
+                'e' => 'f',
+            ])
+            // insert using single value
+            ->value('g', 'h');
 
         $this->assertEquals(
-        'INSERT INTO `test` (a, c, e, g) VALUES (:val_a, :val_c, :val_e, :val_g)',
-        $insert,
-        'insert must equal with query 1 new row with 2 data'
-      );
+            'INSERT INTO `test` (a, c, e, g) VALUES (:val_a, :val_c, :val_e, :val_g)',
+            $insert,
+            'insert must equal with query 1 new row with 2 data'
+        );
     }
 
     /** @test */
@@ -177,72 +168,66 @@ final class QueryStringTest extends TestCase
     {
         $update            = [];
         $update['between'] = MyQuery::from('test', $this->PDO)
-      ->update()
-      ->value('a', 'b')
-      ->between('coulumn_1', 1, 100)
-    ;
+            ->update()
+            ->value('a', 'b')
+            ->between('coulumn_1', 1, 100);
 
         $update['compare'] = MyQuery::from('test', $this->PDO)
-      ->update()
-      ->value('a', 'b')
-      ->compare('ten', '>', 9)
-    ;
+            ->update()
+            ->value('a', 'b')
+            ->compare('ten', '>', 9);
 
         $update['equal'] = MyQuery::from('test', $this->PDO)
-      ->update()
-      ->value('a', 'b')
-      ->equal('ten', 10)
-    ;
+            ->update()
+            ->value('a', 'b')
+            ->equal('ten', 10);
 
         $update['in'] = MyQuery::from('test', $this->PDO)
-      ->update()
-      ->value('a', 'b')
-      ->in('column_1', [1, 2, 3, 4, 5])
-    ;
+            ->update()
+            ->value('a', 'b')
+            ->in('column_1', [1, 2, 3, 4, 5]);
 
         $update['like'] = MyQuery::from('test', $this->PDO)
-      ->update()
-      ->value('a', 'b')
-      ->like('i', 'you')
-    ;
+            ->update()
+            ->value('a', 'b')
+            ->like('i', 'you');
 
         $update['where'] = MyQuery::from('test', $this->PDO)
-      ->update()
-      ->value('a', 'b')
-      ->where('col1 = :col1 OR col2 = :col2', ['col1' => 1, 'col2' => 2])
-    ;
+            ->update()
+            ->value('a', 'b')
+            ->where('col1 = :col1 OR col2 = :col2', ['col1' => 1, 'col2' => 2]);
 
         // assertation
 
         $this->assertEquals(
-        'UPDATE `test` SET `a` = :val_a WHERE (`test`.`coulumn_1` BETWEEN :b_start AND :b_end)',
-        $update['between'],
-        'update query must same with between operator'
-      );
+            'UPDATE `test` SET `a` = :val_a WHERE (`test`.`coulumn_1` BETWEEN :b_start AND :b_end)',
+            $update['between'],
+            'update query must same with between operator'
+        );
 
         $this->assertEquals(
-        'UPDATE `test` SET `a` = :val_a WHERE ( (test.ten > :ten) )',
-        $update['compare'],
-        'update query must same with compire operator'
-      );
+            'UPDATE `test` SET `a` = :val_a WHERE ( (test.ten > :ten) )',
+            $update['compare'],
+            'update query must same with compire operator'
+        );
 
         $this->assertEquals(
-        'UPDATE `test` SET `a` = :val_a WHERE ( (test.ten = :ten) )',
-        $update['equal'],
-        'update query must same with equal operator'
-      );
+            'UPDATE `test` SET `a` = :val_a WHERE ( (test.ten = :ten) )',
+            $update['equal'],
+            'update query must same with equal operator'
+        );
 
         $this->assertEquals(
-        'UPDATE `test` SET `a` = :val_a WHERE (`test`.`column_1` IN (:in_0, :in_1, :in_2, :in_3, :in_4))',
-        $update['in'],
-        'update query must same with in operator'
-      );
+            'UPDATE `test` SET `a` = :val_a WHERE (`test`.`column_1` IN (:in_0, :in_1, :in_2, :in_3, :in_4))',
+            $update['in'],
+            'update query must same with in operator'
+        );
 
         $this->assertEquals(
-        'UPDATE `test` SET `a` = :val_a WHERE col1 = :col1 OR col2 = :col2',
-        $update['where'],
-        'update query must same with where operator'
-      );
+            'UPDATE `test` SET `a` = :val_a WHERE col1 = :col1 OR col2 = :col2',
+            $update['where'],
+            'update query must same with where operator'
+        );
     }
 
     /** @test */
@@ -250,66 +235,60 @@ final class QueryStringTest extends TestCase
     {
         $delete            = [];
         $delete['between'] = MyQuery::from('test', $this->PDO)
-      ->delete()
-      ->between('coulumn_1', 1, 100)
-    ;
+            ->delete()
+            ->between('coulumn_1', 1, 100);
 
         $delete['compare'] = MyQuery::from('test', $this->PDO)
-      ->delete()
-      ->compare('ten', '>', 9)
-    ;
+            ->delete()
+            ->compare('ten', '>', 9);
 
         $delete['equal'] = MyQuery::from('test', $this->PDO)
-      ->delete()
-      ->equal('ten', 10)
-    ;
+            ->delete()
+            ->equal('ten', 10);
 
         $delete['in'] = MyQuery::from('test', $this->PDO)
-      ->delete()
-      ->in('column_1', [1, 2, 3, 4, 5])
-    ;
+            ->delete()
+            ->in('column_1', [1, 2, 3, 4, 5]);
 
         $delete['like'] = MyQuery::from('test', $this->PDO)
-      ->delete()
-      ->like('i', 'you')
-    ;
+            ->delete()
+            ->like('i', 'you');
 
         $delete['where'] = MyQuery::from('test', $this->PDO)
-      ->delete()
-      ->where('col1 = :col1 OR col2 = :col2', ['col1' => 1, 'col2' => 2])
-    ;
+            ->delete()
+            ->where('col1 = :col1 OR col2 = :col2', ['col1' => 1, 'col2' => 2]);
 
         // assertation
 
         $this->assertEquals(
-        'DELETE FROM `test` WHERE (`test`.`coulumn_1` BETWEEN :b_start AND :b_end)',
-        $delete['between'],
-        'delete query must same with between operator'
-      );
+            'DELETE FROM `test` WHERE (`test`.`coulumn_1` BETWEEN :b_start AND :b_end)',
+            $delete['between'],
+            'delete query must same with between operator'
+        );
 
         $this->assertEquals(
-        'DELETE FROM `test` WHERE ( (test.ten > :ten) )',
-        $delete['compare'],
-        'delete query must same with compire operator'
-      );
+            'DELETE FROM `test` WHERE ( (test.ten > :ten) )',
+            $delete['compare'],
+            'delete query must same with compire operator'
+        );
 
         $this->assertEquals(
-        'DELETE FROM `test` WHERE ( (test.ten = :ten) )',
-        $delete['equal'],
-        'delete query must same with equal operator'
-      );
+            'DELETE FROM `test` WHERE ( (test.ten = :ten) )',
+            $delete['equal'],
+            'delete query must same with equal operator'
+        );
 
         $this->assertEquals(
-        'DELETE FROM `test` WHERE (`test`.`column_1` IN (:in_0, :in_1, :in_2, :in_3, :in_4))',
-        $delete['in'],
-        'delete query must same with in operator'
-      );
+            'DELETE FROM `test` WHERE (`test`.`column_1` IN (:in_0, :in_1, :in_2, :in_3, :in_4))',
+            $delete['in'],
+            'delete query must same with in operator'
+        );
 
         $this->assertEquals(
-        'DELETE FROM `test` WHERE col1 = :col1 OR col2 = :col2',
-        $delete['where'],
-        'delete query must same with where operator'
-      );
+            'DELETE FROM `test` WHERE col1 = :col1 OR col2 = :col2',
+            $delete['where'],
+            'delete query must same with where operator'
+        );
     }
 
     /** @test */
@@ -317,93 +296,97 @@ final class QueryStringTest extends TestCase
     {
         // inner join
         $select['inner'] = MyQuery::from('base_table', $this->PDO)
-      ->select()
-      ->join(InnerJoin::ref('join_table', 'base_id', 'join_id'))
-    ;
+            ->select()
+            ->join(InnerJoin::ref('join_table', 'base_id', 'join_id'));
 
         $this->assertEquals(
-      'SELECT * FROM `base_table` INNER JOIN join_table ON base_table.base_id = join_table.join_id',
-      $select['inner'],
-      'expect select inner join'
-    );
+            'SELECT * FROM `base_table` INNER JOIN join_table ON base_table.base_id = join_table.join_id',
+            $select['inner'],
+            'expect select inner join'
+        );
 
         // left join
         $select['left'] = MyQuery::from('base_table', $this->PDO)
-      ->select()
-      ->join(LeftJoin::ref('join_table', 'base_id', 'join_id'))
-    ;
+            ->select()
+            ->join(LeftJoin::ref('join_table', 'base_id', 'join_id'));
 
         $this->assertEquals(
-      'SELECT * FROM `base_table` LEFT JOIN join_table ON base_table.base_id = join_table.join_id',
-      $select['left'],
-      'expect select left join'
-    );
+            'SELECT * FROM `base_table` LEFT JOIN join_table ON base_table.base_id = join_table.join_id',
+            $select['left'],
+            'expect select left join'
+        );
 
         // right join
         $select['right'] = MyQuery::from('base_table', $this->PDO)
-      ->select()
-      ->join(RightJoin::ref('join_table', 'base_id', 'join_id'))
-    ;
+            ->select()
+            ->join(RightJoin::ref('join_table', 'base_id', 'join_id'));
 
         $this->assertEquals(
-      'SELECT * FROM `base_table` RIGHT JOIN join_table ON base_table.base_id = join_table.join_id',
-      $select['right'],
-      'expect select right join'
-    );
+            'SELECT * FROM `base_table` RIGHT JOIN join_table ON base_table.base_id = join_table.join_id',
+            $select['right'],
+            'expect select right join'
+        );
 
         // full join
         $select['full'] = MyQuery::from('base_table', $this->PDO)
-      ->select()
-      ->join(FullJoin::ref('join_table', 'base_id', 'join_id'))
-    ;
+            ->select()
+            ->join(FullJoin::ref('join_table', 'base_id', 'join_id'));
 
         $this->assertEquals(
-      'SELECT * FROM `base_table` FULL OUTER JOIN join_table ON base_table.base_id = join_table.join_id',
-      $select['full'],
-      'expect select full join'
-    );
+            'SELECT * FROM `base_table` FULL OUTER JOIN join_table ON base_table.base_id = join_table.join_id',
+            $select['full'],
+            'expect select full join'
+        );
+
+        // cross join
+        $select['cross'] = MyQuery::from('base_table', $this->PDO)
+            ->select()
+            ->join(CrossJoin::ref('join_table', 'base_table'));
+
+        $this->assertEquals(
+            'SELECT * FROM `base_table` CROSS JOIN join_table',
+            $select['cross']
+        );
     }
 
     /** @test */
     public function itCanGenerateWhereExitsQuery(): void
     {
         $select = MyQuery::from('base_1', $this->PDO)
-      ->select()
-      ->whereExist(
-        (new Select('base_2', ['*'], $this->PDO))
-        // Select::from('base_2')
-          ->equal('test', 'success')
-          ->where('base_1.id = base_2.id')
-      )
-      ->limit(1, 10)
-      ->order('id', MyQuery::ORDER_ASC)
-      ->__toString()
-    ;
+            ->select()
+            ->whereExist(
+                (new Select('base_2', ['*'], $this->PDO))
+                // Select::from('base_2')
+                ->equal('test', 'success')
+                ->where('base_1.id = base_2.id')
+            )
+            ->limit(1, 10)
+            ->order('id', MyQuery::ORDER_ASC)
+            ->__toString();
 
         $this->assertEquals(
-      'SELECT * FROM `base_1` WHERE EXISTS (SELECT * FROM `base_2` WHERE ( (base_2.test = :test) ) AND base_1.id = base_2.id) ORDER BY `base_1`.`id` ASC LIMIT 1, 10',
-      $select,
-      'where exist query'
-    );
+            'SELECT * FROM `base_1` WHERE EXISTS (SELECT * FROM `base_2` WHERE ( (base_2.test = :test) ) AND base_1.id = base_2.id) ORDER BY `base_1`.`id` ASC LIMIT 1, 10',
+            $select,
+            'where exist query'
+        );
 
         // where not exist
         $select = MyQuery::from('base_1', $this->PDO)
-      ->select()
-      ->whereNotExist(
-        (new Select('base_2', ['*'], $this->PDO))
-        // Select::from('base_2', $this->PDO)
-          ->equal('test', 'success')
-          ->where('base_1.id = base_2.id')
-      )
-      ->limit(1, 10)
-      ->order('id', MyQuery::ORDER_ASC)
-      ->__toString()
-    ;
+            ->select()
+            ->whereNotExist(
+                (new Select('base_2', ['*'], $this->PDO))
+                // Select::from('base_2', $this->PDO)
+                ->equal('test', 'success')
+                ->where('base_1.id = base_2.id')
+            )
+            ->limit(1, 10)
+            ->order('id', MyQuery::ORDER_ASC)
+            ->__toString();
 
         $this->assertEquals(
-      'SELECT * FROM `base_1` WHERE NOT EXISTS (SELECT * FROM `base_2` WHERE ( (base_2.test = :test) ) AND base_1.id = base_2.id) ORDER BY `base_1`.`id` ASC LIMIT 1, 10',
-      $select,
-      'where exist query'
-    );
+            'SELECT * FROM `base_1` WHERE NOT EXISTS (SELECT * FROM `base_2` WHERE ( (base_2.test = :test) ) AND base_1.id = base_2.id) ORDER BY `base_1`.`id` ASC LIMIT 1, 10',
+            $select,
+            'where exist query'
+        );
     }
 }

--- a/tests/Support/Facedes/FacedeTest.php
+++ b/tests/Support/Facedes/FacedeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use System\Integrate\Application;
+
+final class FacedeTest extends TestCase
+{
+    /** @test */
+    final public function itCanCallstatic()
+    {
+        $app = new Application(__DIR__);
+        $app->set(System\Time\Now::class, fn () => new System\Time\Now());
+
+        require_once __DIR__ . DIRECTORY_SEPARATOR . 'Sample' . DIRECTORY_SEPARATOR . 'FacedesTestClass.php';
+        (new FacedesTestClass($app));
+
+        FacedesTestClass::year(2023);
+        $year = FacedesTestClass::isNextYear();
+
+        $this->assertTrue($year);
+    }
+}

--- a/tests/Support/Facedes/Sample/FacedesTestClass.php
+++ b/tests/Support/Facedes/Sample/FacedesTestClass.php
@@ -1,0 +1,15 @@
+<?php
+
+use System\Support\Facedes\Facede;
+
+/**
+ * @method static \System\Time\Now year(int $year)
+ * @method static bool isNextYear()
+ */
+final class FacedesTestClass extends Facede
+{
+    protected static function setAccessor()
+    {
+        static::$accessor = static::$app->get(System\Time\Now::class);
+    }
+}

--- a/tests/Support/Facedes/Sample/FacedesTestClass.php
+++ b/tests/Support/Facedes/Sample/FacedesTestClass.php
@@ -8,8 +8,8 @@ use System\Support\Facedes\Facede;
  */
 final class FacedesTestClass extends Facede
 {
-    protected static function setAccessor()
+    protected static function getAccessor()
     {
-        static::$accessor = static::$app->get(System\Time\Now::class);
+        return System\Time\Now::class;
     }
 }


### PR DESCRIPTION
- deprecated `MyQuery::getInstance`.
- added `Facede::class` abstract class. 
- added `MyPDO::instance`.
- added `CrossJoin::class` query builder for join table query.
- PHPStan level 6 for `System\Database` exclude `MyModel::class`.