### PR TITLE
More Commandline Color Palette

### DIFF
--- a/src/System/Console/Command.php
+++ b/src/System/Console/Command.php
@@ -123,17 +123,39 @@ class Command
     }
 
     // asset
-    public const TEXT_DIM    = 2;
-    public const TEXT_RED    = 31;
-    public const TEXT_GREEN  = 32;
-    public const TEXT_YELLOW = 33;
-    public const TEXT_BLUE   = 34;
-    public const TEXT_WHITE  = 97;
-    public const BG_RED      = 41;
-    public const BG_GREEN    = 42;
-    public const BG_YELLOW   = 43;
-    public const BG_BLUE     = 44;
-    public const BG_WHITE    = 107;
+    public const TEXT_DEFAULT             = 39;
+    public const TEXT_DIM                 = 2;
+    public const TEXT_RED                 = 31;
+    public const TEXT_GREEN               = 32;
+    public const TEXT_YELLOW              = 33;
+    public const TEXT_BLUE                = 34;
+    public const TEXT_MAGENTA             = 35;
+    public const TEXT_CYAN                = 36;
+    public const TEXT_LIGHT_GRAY          = 37;
+    public const TEXT_DARK_GRAY           = 90;
+    public const TEXT_LIGHT_RED           = 91;
+    public const TEXT_LIGHT_GREEN         = 92;
+    public const TEXT_LIGHT_YELLOW        = 93;
+    public const TEXT_LIGHT_BLUE          = 94;
+    public const TEXT_LIGHT_MAGENTA       = 95;
+    public const TEXT_LIGHT_CYAN          = 96;
+    public const TEXT_WHITE               = 97;
+    public const BG_DEFAULT               = 49;
+    public const BG_RED                   = 41;
+    public const BG_GREEN                 = 42;
+    public const BG_YELLOW                = 43;
+    public const BG_BLUE                  = 44;
+    public const BG_MAGENTA               = 45;
+    public const BG_CYAN                  = 46;
+    public const BG_LIGHT_GRAY            = 47;
+    public const BG_DARK_GRAY             = 100;
+    public const BG_LIGHT_RED             = 101;
+    public const BG_LIGHT_GREEN           = 102;
+    public const BG_LIGHT_YELLOW          = 103;
+    public const BG_LIGHT_BLUE            = 104;
+    public const BG_LIGHT_MAGENTA         = 105;
+    public const BG_LIGHT_CYAN            = 106;
+    public const BG_WHITE                 = 107;
     // more code see https://misc.flogisoft.com/bash/tip_colors_and_formatting
 
     /**

--- a/src/System/Console/Command.php
+++ b/src/System/Console/Command.php
@@ -124,10 +124,10 @@ class Command
 
     // asset
     public const TEXT_DIM    = 2;
-    public const TEXT_RED    = 32;
-    public const TEXT_GREEN  = 33;
-    public const TEXT_YELLOW = 34;
-    public const TEXT_BLUE   = 35;
+    public const TEXT_RED    = 31;
+    public const TEXT_GREEN  = 32;
+    public const TEXT_YELLOW = 33;
+    public const TEXT_BLUE   = 34;
     public const TEXT_WHITE  = 97;
     public const BG_RED      = 41;
     public const BG_GREEN    = 42;

--- a/src/System/Console/TraitCommand.php
+++ b/src/System/Console/TraitCommand.php
@@ -7,14 +7,31 @@ trait TraitCommand
     /**
      * Run commandline text rule.
      *
-     * @param array<int, string> $rule
+     * @param array<int, string|int> $rule
      */
     protected function rules(array $rule, string $text, bool $reset_rule = true): string
     {
-        $toString = implode(';', $rule);
-        $string   = "\e[$toString" . "m$text";
+        $string_rules = implode(';', $rule);
 
-        return $reset_rule ? $string . "\e[0m" : $string;
+        return $this->rule($string_rules, $text, $reset_rule);
+    }
+
+    /**
+     * Run color code.
+     *
+     * @param int|string $rule
+     * @param string     $text
+     * @param bool       $reset
+     *
+     * @return string
+     */
+    protected function rule($rule, $text, $reset = true)
+    {
+        $rule = "\e[" . $rule . 'm' . $text;
+
+        return $reset
+            ? $rule . "\e[0m"
+            : $rule;
     }
 
     /**
@@ -56,72 +73,247 @@ trait TraitCommand
      */
     protected function clear_line()
     {
-        echo "\033[1K";
+        echo "\e[1K";
     }
 
     /** code (bash): 31 */
     protected function textRed(string $text): string
     {
-        return "\e[31m$text\e[0m";
+        return $this->rule(Command::TEXT_RED, $text);
     }
 
     /** code (bash): 33 */
     protected function textYellow(string $text): string
     {
-        return "\e[33m$text\e[0m";
+        return $this->rule(Command::TEXT_YELLOW, $text);
     }
 
     /** code (bash): 32 */
     protected function textGreen(string $text): string
     {
-        return "\e[32m$text\e[0m";
+        return $this->rule(Command::TEXT_GREEN, $text);
     }
 
     /** code (bash): 34 */
     protected function textBlue(string $text): string
     {
-        return "\e[34m$text\e[0m";
+        return $this->rule(Command::TEXT_BLUE, $text);
     }
 
     /** code (bash): 2 */
     protected function textDim(string $text): string
     {
-        return "\e[2m$text\e[0m";
+        return $this->rule(Command::TEXT_DIM, $text);
+    }
+
+    /** code (bash): 35 */
+    protected function textMageta(string $text): string
+    {
+        return $this->rule(Command::TEXT_MAGENTA, $text);
+    }
+
+    /** code (bash): 36 */
+    protected function textCyan(string $text): string
+    {
+        return $this->rule(Command::TEXT_CYAN, $text);
+    }
+
+    /** code (bash): 37 */
+    protected function textLightGray(string $text): string
+    {
+        return $this->rule(Command::TEXT_LIGHT_GRAY, $text);
+    }
+
+    /** code (bash): 90 */
+    protected function textDarkGray(string $text): string
+    {
+        return $this->rule(Command::TEXT_DARK_GRAY, $text);
+    }
+
+    /** code (bash): 91 */
+    protected function textLightRed(string $text): string
+    {
+        return $this->rule(Command::TEXT_LIGHT_RED, $text);
+    }
+
+    /** code (bash): 92 */
+    protected function textLightGreen(string $text): string
+    {
+        return $this->rule(Command::TEXT_LIGHT_GREEN, $text);
+    }
+
+    /** code (bash): 93 */
+    protected function textLightYellow(string $text): string
+    {
+        return $this->rule(Command::TEXT_LIGHT_YELLOW, $text);
+    }
+
+    /** code (bash): 94 */
+    protected function textLightBlue(string $text): string
+    {
+        return $this->rule(Command::TEXT_LIGHT_BLUE, $text);
+    }
+
+    /** code (bash): 95 */
+    protected function textLightMagenta(string $text): string
+    {
+        return $this->rule(Command::TEXT_LIGHT_MAGENTA, $text);
+    }
+
+    /** code (bash): 96 */
+    protected function textLightCyan(string $text): string
+    {
+        return $this->rule(Command::TEXT_LIGHT_CYAN, $text);
     }
 
     /** code (bash): 97 */
     protected function textWhite(string $text): string
     {
-        return "\e[97m$text\e[0m";
+        return $this->rule(Command::TEXT_WHITE, $text);
     }
 
     /** code (bash): 41 */
     protected function bgRed(string $text): string
     {
-        return "\e[41m$text\e[0m";
+        return $this->rule(Command::BG_RED, $text);
     }
 
     /** code (bash): 43 */
     protected function bgYellow(string $text): string
     {
-        return "\e[43m$text\e[0m";
+        return $this->rule(Command::BG_YELLOW, $text);
     }
 
     /** code (bash): 42 */
     protected function bgGreen(string $text): string
     {
-        return "\e[42m$text\e[0m";
+        return $this->rule(Command::BG_GREEN, $text);
     }
 
     /** code (bash): 44 */
     protected function bgBlue(string $text): string
     {
-        return "\e[44m$text\e[0m";
+        return $this->rule(Command::BG_BLUE, $text);
+    }
+
+    /** code (bash): 45 */
+    protected function bgMagenta(string $text): string
+    {
+        return $this->rule(Command::BG_MAGENTA, $text);
+    }
+
+    /** code (bash): 46 */
+    protected function bgCyan(string $text): string
+    {
+        return $this->rule(Command::BG_CYAN, $text);
+    }
+
+    /** code (bash): 47 */
+    protected function bgLightGray(string $text): string
+    {
+        return $this->rule(Command::BG_LIGHT_GRAY, $text);
+    }
+
+    /** code (bash): 100 */
+    protected function bgDrakGray(string $text): string
+    {
+        return $this->rule(Command::BG_DARK_GRAY, $text);
+    }
+
+    /** code (bash): 101 */
+    protected function bgLightRed(string $text): string
+    {
+        return $this->rule(Command::BG_LIGHT_RED, $text);
+    }
+
+    /** code (bash): 102 */
+    protected function bgLightGreen(string $text): string
+    {
+        return $this->rule(Command::BG_LIGHT_GREEN, $text);
+    }
+
+    /** code (bash): 103 */
+    protected function bgLightYellow(string $text): string
+    {
+        return $this->rule(Command::BG_LIGHT_YELLOW, $text);
+    }
+
+    /** code (bash): 104 */
+    protected function bgLightBlue(string $text): string
+    {
+        return $this->rule(Command::BG_LIGHT_BLUE, $text);
+    }
+
+    /** code (bash): 105 */
+    protected function bgLightMagenta(string $text): string
+    {
+        return $this->rule(Command::BG_LIGHT_MAGENTA, $text);
+    }
+
+    /** code (bash): 106 */
+    protected function bgLightCyan(string $text): string
+    {
+        return $this->rule(Command::BG_LIGHT_CYAN, $text);
     }
 
     /** code (bash): 107 */
     protected function bgWhite(string $text): string
     {
-        return "\e[107m$text\e[0m";
+        return $this->rule(Command::BG_WHITE, $text);
+    }
+
+    // JIT color
+
+    /**
+     * Just in time text color.
+     *
+     * @param int $color Color code 0-256
+     */
+    protected function textColor(int $color, string $text): string
+    {
+        if ($color < 0 | $color > 256) {
+            throw new \InvalidArgumentException('Color code must 0-256 range.');
+        }
+
+        return $this->rules([38, 5, $color], $text);
+    }
+
+    /**
+     * Just in time bachgroud color.
+     *
+     * @param int $color Color code 0-256
+     */
+    protected function bgColor(int $color, string $text): string
+    {
+        if ($color < 0 | $color > 256) {
+            throw new \InvalidArgumentException('Color code must 0-256 range.');
+        }
+
+        return $this->rules([48, 5, $color], $text);
+    }
+
+    protected function textBold(string $text): string
+    {
+        return "\e[1m" . $text . "\e[21m";
+    }
+
+    protected function textUnderline(string $text): string
+    {
+        return "\e[4m" . $text . "\e[24m";
+    }
+
+    protected function textBlink(string $text): string
+    {
+        return "\e[5m" . $text . "\e[25m";
+    }
+
+    protected function textReverse(string $text): string
+    {
+        return "\e[7m" . $text . "\e[27m";
+    }
+
+    protected function textHidden(string $text): string
+    {
+        return "\e[8m" . $text . "\e[28m";
     }
 }

--- a/src/System/Console/TraitCommand.php
+++ b/src/System/Console/TraitCommand.php
@@ -107,7 +107,7 @@ trait TraitCommand
     }
 
     /** code (bash): 35 */
-    protected function textMageta(string $text): string
+    protected function textMagenta(string $text): string
     {
         return $this->rule(Command::TEXT_MAGENTA, $text);
     }
@@ -215,7 +215,7 @@ trait TraitCommand
     }
 
     /** code (bash): 100 */
-    protected function bgDrakGray(string $text): string
+    protected function bgDarkGray(string $text): string
     {
         return $this->rule(Command::BG_DARK_GRAY, $text);
     }
@@ -279,7 +279,7 @@ trait TraitCommand
     }
 
     /**
-     * Just in time bachgroud color.
+     * Just in time background color.
      *
      * @param int $color Color code 0-256
      */

--- a/tests/Console/TraitCommanndTest.php
+++ b/tests/Console/TraitCommanndTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use System\Console\Command;
+
+final class TraitCommandTest extends TestCase
+{
+    /** @var class */
+    private $command;
+
+    protected function setUp(): void
+    {
+        $this->command = new class(['cli', '--test']) extends Command {
+            public function __call($name, $arguments)
+            {
+                if ($name === 'echoTextRed') {
+                    echo $this->textRed('Color');
+                }
+                if ($name === 'echoTextYellow') {
+                    echo $this->textYellow('Color');
+                }
+                if ($name === 'echoTextGreen') {
+                    echo $this->textGreen('Color');
+                }
+                if ($name === 'textColor') {
+                    echo $this->textColor((int) $arguments[0], 'Color');
+                }
+            }
+        };
+    }
+
+    /** @test */
+    public function itCanMakeTextRed()
+    {
+        ob_start();
+        $this->command->echoTextRed();
+        $out = ob_get_clean();
+
+        $this->assertEquals("\e[31mColor\e[0m", $out);
+    }
+
+    /** @test */
+    public function itCanMakeTextYellow()
+    {
+        ob_start();
+        $this->command->echoTextYellow();
+        $out = ob_get_clean();
+
+        $this->assertEquals("\e[33mColor\e[0m", $out);
+    }
+
+    /** @test */
+    public function itCanMakeTextGreen()
+    {
+        ob_start();
+        $this->command->echoTextGreen();
+        $out = ob_get_clean();
+
+        $this->assertEquals("\e[32mColor\e[0m", $out);
+    }
+
+    /** @test */
+    public function itCanMakeTextColor()
+    {
+        ob_start();
+        $this->command->textColor(25);
+        $out = ob_get_clean();
+
+        $this->assertEquals("\e[38;5;25mColor\e[0m", $out);
+    }
+}


### PR DESCRIPTION
- Fixed wrong color code.
- Added text and background color cyan, magenta, light cyan, light magenta, light red, light yellow, light blue, light gray, dark gray.
- Added just in time text and background color (0-256) color code.
- Added Bold, underline, reverse and hidden.
- Test unit for `TraitConsole`.