### PR TITLE
Restructor folder/file tree

### DIFF
--- a/src/System/Console/Style/Decorate.php
+++ b/src/System/Console/Style/Decorate.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace System\Console;
+namespace System\Console\Style;
 
 class Decorate
 {

--- a/src/System/Console/Traits/CommandTrait.php
+++ b/src/System/Console/Traits/CommandTrait.php
@@ -1,84 +1,12 @@
 <?php
 
-namespace System\Console;
+namespace System\Console\Traits;
 
-trait TraitCommand
+use System\Console\Style\Decorate;
+
+trait CommandTrait
 {
-    /**
-     * Run commandline text rule.
-     *
-     * @param array<int, string|int> $rule
-     * @param array<int, string|int> $reset_rule
-     */
-    protected function rules(array $rule, string $text, bool $reset = true, array $reset_rule = [Decorate::RESET]): string
-    {
-        $string_rules       = implode(';', $rule);
-        $string_reset_rules = implode(';', $reset_rule);
-
-        return $this->rule($string_rules, $text, $reset, $string_reset_rules);
-    }
-
-    /**
-     * Run color code.
-     *
-     * @param int|string $rule
-     * @param string     $text
-     * @param bool       $reset
-     * @param int|string $reset_rule
-     *
-     * @return string
-     */
-    protected function rule($rule, $text, $reset = true, $reset_rule = Decorate::RESET)
-    {
-        $rule       = "\e[" . $rule . 'm' . $text;
-        $reset_rule = "\e[" . $reset_rule . 'm';
-
-        return $reset
-            ? $rule . $reset_rule
-            : $rule;
-    }
-
-    /**
-     * Echo array of string.
-     *
-     * @param array<int, string> $string
-     */
-    protected function prints(array $string): void
-    {
-        foreach ($string as $print) {
-            echo $print;
-        }
-    }
-
-    protected function print_n(int $count = 1): void
-    {
-        echo str_repeat("\n", $count);
-    }
-
-    protected function print_t(int $count = 1): void
-    {
-        echo str_repeat("\t", $count);
-    }
-
-    protected function newLine(int $count = 1): string
-    {
-        return str_repeat("\n", $count);
-    }
-
-    protected function tabs(int $count = 1): string
-    {
-        return str_repeat("\t", $count);
-    }
-
-    /**
-     * Clear from the cursor position to the beginning of the line.
-     *
-     * @return void
-     */
-    protected function clear_cursor()
-    {
-        echo "\e[1K";
-    }
+    use PrinterTrait;
 
     /**
      * Clear everything on the line.

--- a/src/System/Console/Traits/CommandTrait.php
+++ b/src/System/Console/Traits/CommandTrait.php
@@ -8,16 +8,6 @@ trait CommandTrait
 {
     use PrinterTrait;
 
-    /**
-     * Clear everything on the line.
-     *
-     * @return void
-     */
-    protected function clear_line()
-    {
-        echo "\e[2K";
-    }
-
     /** code (bash): 31 */
     protected function textRed(string $text): string
     {

--- a/src/System/Console/Traits/PrinterTrait.php
+++ b/src/System/Console/Traits/PrinterTrait.php
@@ -71,4 +71,14 @@ trait PrinterTrait
     {
         echo "\e[1K";
     }
+
+    /**
+     * Clear everything on the line.
+     *
+     * @return void
+     */
+    protected function clear_line()
+    {
+        echo "\e[2K";
+    }
 }

--- a/src/System/Console/Traits/PrinterTrait.php
+++ b/src/System/Console/Traits/PrinterTrait.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace System\Console\Traits;
+
+use System\Console\Style\Decorate;
+
+trait PrinterTrait
+{
+    /**
+     * Run commandline text rule.
+     *
+     * @param array<int, string|int> $rule
+     * @param array<int, string|int> $reset_rule
+     */
+    protected function rules(array $rule, string $text, bool $reset = true, array $reset_rule = [Decorate::RESET]): string
+    {
+        $string_rules       = implode(';', $rule);
+        $string_reset_rules = implode(';', $reset_rule);
+
+        return $this->rule($string_rules, $text, $reset, $string_reset_rules);
+    }
+
+    /**
+     * Run color code.
+     *
+     * @param int|string $rule
+     * @param string     $text
+     * @param bool       $reset
+     * @param int|string $reset_rule
+     *
+     * @return string
+     */
+    protected function rule($rule, $text, $reset = true, $reset_rule = Decorate::RESET)
+    {
+        $rule       = "\e[" . $rule . 'm' . $text;
+        $reset_rule = "\e[" . $reset_rule . 'm';
+
+        return $reset
+            ? $rule . $reset_rule
+            : $rule;
+    }
+
+    protected function print_n(int $count = 1): void
+    {
+        echo str_repeat("\n", $count);
+    }
+
+    protected function print_t(int $count = 1): void
+    {
+        echo str_repeat("\t", $count);
+    }
+
+    protected function newLine(int $count = 1): string
+    {
+        return str_repeat("\n", $count);
+    }
+
+    protected function tabs(int $count = 1): string
+    {
+        return str_repeat("\t", $count);
+    }
+
+    /**
+     * Clear from the cursor position to the beginning of the line.
+     *
+     * @return void
+     */
+    protected function clear_cursor()
+    {
+        echo "\e[1K";
+    }
+}

--- a/tests/Console/ConsoleParseTest.php
+++ b/tests/Console/ConsoleParseTest.php
@@ -2,7 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use System\Console\Command;
-use System\Console\TraitCommand;
+use System\Console\Traits\CommandTrait;
 
 class ConsoleParseTest extends TestCase
 {
@@ -75,7 +75,7 @@ class ConsoleParseTest extends TestCase
     public function itCanRunMainMethod()
     {
         $console = new class(['test', '--test', 'Oke']) extends Command {
-            use TraitCommand;
+            use CommandTrait;
 
             public function main()
             {

--- a/tests/Console/TraitCommandTest.php
+++ b/tests/Console/TraitCommandTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use System\Console\Command;
-use System\Console\TraitCommand;
+use System\Console\Traits\CommandTrait;
 
 final class TraitCommandTest extends TestCase
 {
@@ -14,7 +14,7 @@ final class TraitCommandTest extends TestCase
     protected function setUp(): void
     {
         $this->command = new class(['cli', '--test']) extends Command {
-            use TraitCommand;
+            use CommandTrait;
 
             public function __call($name, $arguments)
             {


### PR DESCRIPTION
Restructur folder (organize fooder)
- move traitcommand.php to traits folder
- move decorate.php to styles folder
- splint trait code (new printertrait.php)

the reason refactor structur folder is to make more easy to maintans code. In feature trait or style may be more that one trait or style.