### PR TITLE
[Feat] Add Support Color Variant in Style

### DIFF
--- a/src/System/Console/Style/Style.php
+++ b/src/System/Console/Style/Style.php
@@ -9,6 +9,7 @@ use System\Console\Style\Color\BackgroundColor;
 use System\Console\Style\Color\ForegroundColor;
 use System\Console\Traits\CommandTrait;
 use System\Text\Str;
+use System\Text\Text;
 
 use function System\Text\text;
 
@@ -183,6 +184,19 @@ class Style
                 $constant            =  'BG' . text($constant)->upper()->slice(2);
                 $this->bg_color_rule = [Decorate::getConst($constant)];
             }
+
+            return $this;
+        }
+
+        $constant = text($name)->upper();
+        if ($constant->startsWith('TEXT_')) {
+            $constant->slice(5);
+            $this->textColor(Colors::hexText(ColorVariant::getConst($constant->__toString())));
+        }
+
+        if ($constant->startsWith('BG_')) {
+            $constant->slice(3);
+            $this->bgColor(Colors::hexBg(ColorVariant::getConst($constant->__toString())));
         }
 
         return $this;

--- a/src/System/Console/Style/Style.php
+++ b/src/System/Console/Style/Style.php
@@ -9,7 +9,6 @@ use System\Console\Style\Color\BackgroundColor;
 use System\Console\Style\Color\ForegroundColor;
 use System\Console\Traits\CommandTrait;
 use System\Text\Str;
-use System\Text\Text;
 
 use function System\Text\text;
 

--- a/tests/Console/Style/StyleTest.php
+++ b/tests/Console/Style/StyleTest.php
@@ -155,4 +155,23 @@ final class StyleTest extends TestCase
 
         $this->assertEquals(sprintf('%s[39;48;2;255;215;135mtext%s[0m', chr(27), chr(27)), $text, 'text must return raw color terminal code');
     }
+
+    /** @test */
+    public function itCanRenderColorVariantUsingMagicCall()
+    {
+        $text = (new Style('text'))->text_red_500();
+
+        $this->assertEquals(sprintf('%s[38;2;244;67;54;49mtext%s[0m', chr(27), chr(27)), $text, 'text must return raw color terminal code');
+
+        $text = (new Style('text'))->bg_blue_500();
+
+        $this->assertEquals(sprintf('%s[39;48;2;33;150;243mtext%s[0m', chr(27), chr(27)), $text, 'text must return raw color terminal code');
+    }
+
+    /** @test */
+    public function itCanThrowExceptionWhenColorVariantNotRegister()
+    {
+        $this->expectError();
+        (new Style('text'))->text_red_10();
+    }
 }


### PR DESCRIPTION
support add text/bg color with color variant (eg; blue_500, blue_100) using magic call.
```
style('text')->text_blue_300()->bg_green_100();
```

using prefix `text_` or `bg_` follow by supported color variant.

see [ColorVariant.php](https://github.com/SonyPradana/php-library/blob/master/src/System/Console/Style/ColorVariant.php)