### PR TITLE
[Feat] Print Help for Option and Argument #51

### DIFF
--- a/src/System/Console/Command.php
+++ b/src/System/Console/Command.php
@@ -41,6 +41,27 @@ class Command
     protected $option_mapper;
 
     /**
+     * Option describe for print.
+     *
+     * @var array<string, string>
+     */
+    protected $option_describes = [];
+
+    /**
+     * Option describe for print.
+     *
+     * @var array<string, string>
+     */
+    protected $argument_describes = [];
+
+    /**
+     * Relation between Option and Argument.
+     *
+     * @var array<string, array<string, string>>
+     */
+    protected $option_relation = [];
+
+    /**
      * Parse commandline.
      *
      * @param array<int, string>                  $argv
@@ -152,16 +173,5 @@ class Command
     public function main()
     {
         // print welcome screen or what ever you want
-    }
-
-    /**
-     * @return string|array<string, array<int, string>> Text or array of text to be echo<
-     */
-    public function printHelp()
-    {
-        return [
-            'option'   => [],
-            'argument' => [],
-        ];
     }
 }

--- a/src/System/Console/Command.php
+++ b/src/System/Console/Command.php
@@ -45,21 +45,21 @@ class Command
      *
      * @var array<string, string>
      */
-    protected $option_describes = [];
+    protected $command_describes = [];
 
     /**
      * Option describe for print.
      *
      * @var array<string, string>
      */
-    protected $argument_describes = [];
+    protected $option_describes = [];
 
     /**
      * Relation between Option and Argument.
      *
      * @var array<string, array<string, string>>
      */
-    protected $option_relation = [];
+    protected $command_relation = [];
 
     /**
      * Parse commandline.

--- a/src/System/Console/Traits/PrintHelpTrait.php
+++ b/src/System/Console/Traits/PrintHelpTrait.php
@@ -5,69 +5,87 @@ declare(strict_types=1);
 namespace System\Console\Traits;
 
 use System\Console\Style\Style;
+use System\Text\Str;
 
 trait PrintHelpTrait
 {
+    /**
+     * Print helper style option.
+     *
+     * @var array<string, string|int>
+     */
+    protected $print_help = [
+        'margin-left'         => 12,
+        'column-1-min-lenght' => 24,
+    ];
+
+    /**
+     * Print argument describe using style console.
+     *
+     * @return Style
+     */
+    public function printCommands(Style $style)
+    {
+        $option_names =  array_keys($this->command_describes);
+
+        $min_length = $this->print_help['column-1-min-lenght'];
+        foreach ($option_names as $name) {
+            $arguments_lenght = 0;
+            if (isset($this->command_relation[$name])) {
+                $arguments        = implode(' ', $this->command_relation[$name]);
+                $arguments_lenght = \strlen($arguments);
+            }
+
+            $lenght = \strlen($name) + $arguments_lenght;
+            if ($lenght > $min_length) {
+                $min_length = $lenght;
+            }
+        }
+
+        foreach ($this->command_describes as $option => $describe) {
+            $arguments = '';
+            if (isset($this->command_relation[$option])) {
+                $arguments = implode(' ', $this->command_relation[$option]);
+                $arguments = ' ' . $arguments;
+            }
+
+            $style->repeat(' ', $this->print_help['margin-left']);
+
+            $style->push($option)->textGreen();
+            $style->push($arguments)->textDim();
+
+            $range = $min_length - (\strlen($option) + \strlen($arguments));
+            $style->repeat(' ', $range + 8);
+
+            $style->push($describe);
+            $style->new_lines();
+        }
+
+        return $style;
+    }
+
     /**
      * Print option describe using style console.
      *
      * @return Style
      */
-    protected function printOption(Style $style)
+    public function printOptions(Style $style)
     {
-        return $this->printHelper($style, $this->option_describes);
-    }
+        $option_names =  array_keys($this->option_describes);
 
-    /**
-     * Print argument describe using style console.
-     *
-     * @return Style
-     */
-    protected function printArgument(Style $style)
-    {
-        return $this->printHelper($style, $this->argument_describes);
-    }
-
-    /**
-     * Print argument describe using style console.
-     *
-     * @param Style                 $style
-     * @param array<string, string> $describes
-     *
-     * @return Style
-     */
-    private function printHelper($style, $describes)
-    {
-        $option_names =  array_keys($describes);
-
-        $max_length = 8;
+        $min_length = $this->print_help['column-1-min-lenght'];
         foreach ($option_names as $name) {
-            $arguments_lenght = 0;
-            if (isset($this->option_relation[$name])) {
-                $arguments        = implode(' ', $this->option_relation[$name]);
-                $arguments_lenght = \strlen($arguments);
-            }
-
-            $lenght = \strlen($name) + $arguments_lenght;
-            if ($lenght > $max_length) {
-                $max_length = $lenght;
+            $lenght = \strlen($name);
+            if ($lenght > $min_length) {
+                $min_length = $lenght;
             }
         }
 
-        foreach ($describes as $option => $describe) {
-            $arguments = '';
-            if (isset($this->option_relation[$option])) {
-                $arguments = implode(' ', $this->option_relation[$option]);
-                $arguments = ' ' . $arguments;
-            }
+        foreach ($this->option_describes as $option => $describe) {
+            $style->repeat(' ', $this->print_help['margin-left']);
 
-            $style->repeat(' ', 4);
-
-            $style->push($option)->textGreen();
-            $style->push($arguments)->textDim();
-
-            $range = $max_length - (\strlen($option) + \strlen($arguments));
-            $style->repeat(' ', $range + 8);
+            $option_name = Str::fillEnd($option, ' ', $min_length + 8);
+            $style->push($option_name)->textDim();
 
             $style->push($describe);
             $style->new_lines();

--- a/src/System/Console/Traits/PrintHelpTrait.php
+++ b/src/System/Console/Traits/PrintHelpTrait.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace System\Console\Traits;
+
+use System\Console\Style\Style;
+
+trait PrintHelpTrait
+{
+    /**
+     * Print option describe using style console.
+     *
+     * @return Style
+     */
+    protected function printOption(Style $style)
+    {
+        return $this->printHelper($style, $this->option_describes);
+    }
+
+    /**
+     * Print argument describe using style console.
+     *
+     * @return Style
+     */
+    protected function printArgument(Style $style)
+    {
+        return $this->printHelper($style, $this->argument_describes);
+    }
+
+    /**
+     * Print argument describe using style console.
+     *
+     * @param Style                 $style
+     * @param array<string, string> $describes
+     *
+     * @return Style
+     */
+    private function printHelper($style, $describes)
+    {
+        $option_names =  array_keys($describes);
+
+        $max_length = 8;
+        foreach ($option_names as $name) {
+            $arguments_lenght = 0;
+            if (isset($this->option_relation[$name])) {
+                $arguments        = implode(' ', $this->option_relation[$name]);
+                $arguments_lenght = \strlen($arguments);
+            }
+
+            $lenght = \strlen($name) + $arguments_lenght;
+            if ($lenght > $max_length) {
+                $max_length = $lenght;
+            }
+        }
+
+        foreach ($describes as $option => $describe) {
+            $arguments = '';
+            if (isset($this->option_relation[$option])) {
+                $arguments = implode(' ', $this->option_relation[$option]);
+                $arguments = ' ' . $arguments;
+            }
+
+            $style->repeat(' ', 4);
+
+            $style->push($option)->textGreen();
+            $style->push($arguments)->textDim();
+
+            $range = $max_length - (\strlen($option) + \strlen($arguments));
+            $style->repeat(' ', $range + 8);
+
+            $style->push($describe);
+            $style->new_lines();
+        }
+
+        return $style;
+    }
+}


### PR DESCRIPTION
- added trait to print option and argument using array
- deprecated `Command::printHelp`

```php
// Some class extend with Command

use PrintHelpTrait;

    public function main()
    {
        $this->option_describes = [
            'test' => 'this will display on your console',
            'test:console' => 'this will display on your console',
        ];

        $this->argument_describes = [
            '--name' => 'set name',
            '--age'  => 'set age'
        ];

        $this->option_relation = [
            'test' => ['--name', '--age'],
            'test:console' => ['--age']
        ];

        $this->printOption(new Style)->out();
        $this->printArgument(new Style)->out();
    }
```