### PR TITLE
[Refactor] Change Constructor Parameter

### DIFF
--- a/src/System/Http/RequestFactory.php
+++ b/src/System/Http/RequestFactory.php
@@ -16,7 +16,7 @@ class RequestFactory
             $this->getHeaders(),
             $this->getMethod(),
             $this->getClient(),
-            fn (): string => file_get_contents('php://input')
+            $this->getRawBody()
         );
     }
 
@@ -73,5 +73,10 @@ class RequestFactory
         return !empty($_SERVER['REMOTE_ADDR'])
             ? trim($_SERVER['REMOTE_ADDR'], '[]')
             : null;
+    }
+
+    private function getRawBody(): ?string
+    {
+        return file_get_contents('php://input') | null;
     }
 }

--- a/src/System/Router/RouteDispatcher.php
+++ b/src/System/Router/RouteDispatcher.php
@@ -50,7 +50,7 @@ final class RouteDispatcher
      */
     public static function dispatchFrom(string $uri, string $method, $routes)
     {
-        $create_request = new Request($uri, null, null, null, null, null, null, $method);
+        $create_request = new Request($uri, [], [], [], [], [], [], $method);
 
         return new static($create_request, $routes);
     }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -26,7 +26,7 @@ class RequestTest extends TestCase
             ['header_1'  => 'header', 'header_2' => 123, 'foo' => 'bar'],
             'GET',
             '127:0:0:1',
-            fn () => '{"respone":"ok"}'
+            '{"respone":"ok"}'
         );
     }
 

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -124,7 +124,7 @@ class ResponseTest extends TestCase
     /** @test */
     public function itCanSetHeaderUsingFollowRequest()
     {
-        $req = new Request('test', null, null, null, null, null, ['test' => 'test']);
+        $req = new Request('test', [], [], [], [], [], ['test' => 'test']);
         $res = new Response('content');
 
         $res->followRequest($req, ['test']);


### PR DESCRIPTION
- `Request::__constructor` parameter now not nullable
- `Request::rawBody` now as string|null
- `Request::getJsonBody` throe exception when rawBody is not array/json