### PR TITLE
[deprecated] `AbstarctMiddleware::handel`

### DIFF
--- a/src/System/Integrate/Http/Karnel.php
+++ b/src/System/Integrate/Http/Karnel.php
@@ -51,8 +51,9 @@ class Karnel
     protected function handle_middleware($middlewares)
     {
         foreach ($middlewares as $middleware) {
-            // prevent duplicate middleware
-            if (in_array($middleware, $this->middleware_used)) {
+            // prevent duplicate middleware and not handle-able
+            if (in_array($middleware, $this->middleware_used)
+            && !method_exists($middleware, 'handle')) {
                 continue;
             }
 

--- a/src/System/Router/AbstractMiddleware.php
+++ b/src/System/Router/AbstractMiddleware.php
@@ -2,21 +2,9 @@
 
 namespace System\Router;
 
+/**
+ * deprecated soon, v0.13.
+ */
 abstract class AbstractMiddleware
 {
-    /**
-     * Run middleware.
-     */
-    public function handle()
-    {
-        // ovveridedable
-    }
-
-    /**
-     * Use for clear middleware if needed.
-     */
-    public function close()
-    {
-        // ovveridedable
-    }
 }

--- a/src/System/Router/Router.php
+++ b/src/System/Router/Router.php
@@ -133,7 +133,7 @@ class Router
     /**
      * Run mindle before run group route.
      *
-     * @param AbstractMiddleware[] $middlewares Middleware
+     * @param array<int, class-string> $middlewares Middleware
      */
     public static function middleware(array $middlewares)
     {


### PR DESCRIPTION
in case some handle middleware request some parameter its nor support in `AbstractMiddleware::class`.

```php
class SomeMiddleware
{
    public function handle(Request $request)
   {
   }
}
```