### PR TITLE
[Fix] Query Concat `Join` and `Where` Statment

### DIFF
--- a/src/System/Database/MyQuery/Select.php
+++ b/src/System/Database/MyQuery/Select.php
@@ -164,23 +164,6 @@ final class Select extends Fetch
     }
 
     /**
-     * Setter strict mode.
-     *
-     * True = operator using AND,
-     * False = operator using OR
-     *
-     * @param bool $value True where statment operation using AND
-     *
-     * @return self
-     */
-    public function strictMode(bool $value)
-    {
-        $this->_strict_mode = $value;
-
-        return $this;
-    }
-
-    /**
      * Build SQL query syntac for bind in next step.
      */
     protected function builder(): string

--- a/src/System/Database/MyQuery/Traits/ConditionTrait.php
+++ b/src/System/Database/MyQuery/Traits/ConditionTrait.php
@@ -167,4 +167,21 @@ trait ConditionTrait
 
         return $this;
     }
+
+    /**
+     * Setter strict mode.
+     *
+     * True = operator using AND,
+     * False = operator using OR
+     *
+     * @param bool $value True where statment operation using AND
+     *
+     * @return self
+     */
+    public function strictMode(bool $value)
+    {
+        $this->_strict_mode = $value;
+
+        return $this;
+    }
 }

--- a/src/System/Database/MyQuery/Traits/ConditionTrait.php
+++ b/src/System/Database/MyQuery/Traits/ConditionTrait.php
@@ -173,14 +173,10 @@ trait ConditionTrait
      *
      * True = operator using AND,
      * False = operator using OR
-     *
-     * @param bool $value True where statment operation using AND
-     *
-     * @return self
      */
-    public function strictMode(bool $value)
+    public function strictMode(bool $strict): self
     {
-        $this->_strict_mode = $value;
+        $this->_strict_mode = $strict;
 
         return $this;
     }

--- a/tests/DataBase/Query/DeleteTest.php
+++ b/tests/DataBase/Query/DeleteTest.php
@@ -127,8 +127,6 @@ final class DeleteTest extends \QueryStringTest
     /** @test */
     public function itCorrectDeleteWithStrictOff(): void
     {
-        $this->markTestIncomplete('support strict mode in update query');
-
         $delete = MyQuery::from('test', $this->PDO)
             ->delete()
             ->equal('column_1', 123)
@@ -136,13 +134,13 @@ final class DeleteTest extends \QueryStringTest
             ->strictMode(false);
 
         $this->assertEquals(
-            'Delete `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = :column_1) OR (test.column_2 = :column_2) )',
-            $delete,
+            'DELETE FROM `test` WHERE ( (test.column_1 = :column_1) OR (test.column_2 = :column_2) )',
+            $delete->__toString(),
             'update statment must have using or statment'
         );
 
         $this->assertEquals(
-            "Delete `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = 123) OR (test.column_2 = 'abc') )",
+            "DELETE FROM `test` WHERE ( (test.column_1 = 123) OR (test.column_2 = 'abc') )",
             $delete->queryBind(),
             'update statment must have using or statment'
         );

--- a/tests/DataBase/Query/JoinTest.php
+++ b/tests/DataBase/Query/JoinTest.php
@@ -107,4 +107,44 @@ final class JoinTest extends \QueryStringTest
             $join->queryBind()
         );
     }
+
+    /** @test */
+    public function itCanJoinMultyple()
+    {
+        $join = MyQuery::from('base_table', $this->PDO)
+            ->select()
+            ->join(InnerJoin::ref('join_table_1', 'base_id', 'join_id'))
+            ->join(InnerJoin::ref('join_table_2', 'base_id', 'join_id'))
+        ;
+
+        $this->assertEquals(
+            'SELECT * FROM `base_table` INNER JOIN join_table_1 ON base_table.base_id = join_table_1.join_id INNER JOIN join_table_2 ON base_table.base_id = join_table_2.join_id',
+            $join->__toString()
+        );
+
+        $this->assertEquals(
+            'SELECT * FROM `base_table` INNER JOIN join_table_1 ON base_table.base_id = join_table_1.join_id INNER JOIN join_table_2 ON base_table.base_id = join_table_2.join_id',
+            $join->queryBind()
+        );
+    }
+
+    /** @test */
+    public function itCanJoinWithCondition()
+    {
+        $join = MyQuery::from('base_table', $this->PDO)
+            ->select()
+            ->equal('a', 1)
+            ->join(InnerJoin::ref('join_table_1', 'base_id', 'join_id'))
+        ;
+
+        $this->assertEquals(
+            'SELECT * FROM `base_table` INNER JOIN join_table_1 ON base_table.base_id = join_table_1.join_id WHERE ( (base_table.a = :a) )',
+            $join->__toString()
+        );
+
+        $this->assertEquals(
+            'SELECT * FROM `base_table` INNER JOIN join_table_1 ON base_table.base_id = join_table_1.join_id WHERE ( (base_table.a = 1) )',
+            $join->queryBind()
+        );
+    }
 }

--- a/tests/DataBase/Query/UpdateTest.php
+++ b/tests/DataBase/Query/UpdateTest.php
@@ -133,8 +133,6 @@ final class UpdateTest extends \QueryStringTest
     /** @test */
     public function itCorrectUpdateWithStrictOff(): void
     {
-        $this->markTestIncomplete('support strict mode in update query');
-
         $update = MyQuery::from('test', $this->PDO)
             ->update()
             ->value('a', 'b')
@@ -143,15 +141,13 @@ final class UpdateTest extends \QueryStringTest
             ->strictMode(false);
 
         $this->assertEquals(
-            'Update `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = :column_1) OR (test.column_2 = :column_2) )',
-            $update,
-            'update statment must have using or statment'
+            'UPDATE `test` SET `a` = :bind_a WHERE ( (test.column_1 = :column_1) OR (test.column_2 = :column_2) )',
+            $update->__toString()
         );
 
         $this->assertEquals(
-            "Update `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = 123) OR (test.column_2 = 'abc') )",
-            $update->queryBind(),
-            'update statment must have using or statment'
+            "UPDATE `test` SET `a` = 'b' WHERE ( (test.column_1 = 123) OR (test.column_2 = 'abc') )",
+            $update->queryBind()
         );
     }
 }


### PR DESCRIPTION
before
```sql
SELECT * FROM `base_table` INNER JOIN join_table_1 ON base_table.base_id = join_table_1.join_idWHERE ( (base_table.a = :a) )
``` 
to
```sql
SELECT * FROM `base_table` INNER JOIN join_table_1 ON base_table.base_id = join_table_1.join_id WHERE ( (base_table.a = :a) )
``` 