### PR TITLE
[Fix] Query Bind Boolean Type Return as Boolean

### DIFF
--- a/src/System/Database/MyQuery/Query.php
+++ b/src/System/Database/MyQuery/Query.php
@@ -197,6 +197,14 @@ abstract class Query
                 return "'" . $value . "'";
             }
 
+            if (is_bool($value)) {
+                if ($value === true) {
+                    return 'true';
+                }
+
+                return 'false';
+            }
+
             return $value;
         }, $values);
 

--- a/tests/DataBase/Query/SelectTest.php
+++ b/tests/DataBase/Query/SelectTest.php
@@ -140,9 +140,8 @@ final class SelectTest extends \QueryStringTest
               'select statment must have 3 selected query'
           );
 
-          $this->markTestIncomplete('bolean return as boolean not 0 or 1');
           $this->assertEquals(
-              "SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = 123) AND (test.column_2 = 'abc') AND (test.column_3 = 1) )",
+              "SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = 123) AND (test.column_2 = 'abc') AND (test.column_3 = true) )",
               $select->queryBind(),
               'select statment must have 3 selected query'
           );


### PR DESCRIPTION
 Query Bind Boolean Type Return as Boolean (string `instead` of int).
```php
MyQuery::from('test', $this->PDO)
      ->select(['column_1', 'column_2', 'column_3'])
      ->equal('column_1', 123)
      ->equal('column_2', 'abc')
      ->equal('column_3', true)
;
```
### Before
```sql
SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = 123) AND (test.column_2 = 'abc') AND (test.column_3 = 1) )
```
### After
```sql
SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (test.column_1 = 123) AND (test.column_2 = 'abc') AND (test.column_3 = true) )
```