### PR TITLE
[Refactor] Command Parse with Minus '-' 

### DIFF
--- a/src/System/Console/Command.php
+++ b/src/System/Console/Command.php
@@ -99,7 +99,7 @@ class Command
         foreach ($argv as $key => $option) {
             if ($this->isCommmadParam($option)) {
                 $key_value = explode('=', $option);
-                $name      = preg_replace('/-(.*?)/', '', $key_value[0]);
+                $name      = preg_replace('/^(-{1,2})/', '', $key_value[0]);
 
                 // param have value
                 if (isset($key_value[1])) {

--- a/tests/Console/ConsoleParseTest.php
+++ b/tests/Console/ConsoleParseTest.php
@@ -64,7 +64,7 @@ class ConsoleParseTest extends TestCase
         // parse long param
         $this->assertEquals(
             'children',
-            $cli->whois,
+            $cli->__get('who-is'),
             'valid parse from long param: --who-is'
         );
     }


### PR DESCRIPTION
Bc alert

Commnad argv parse with '-' instead of ''.
```bash
php cli --some-param test
```
Before to get `test` as result
`someparam`
After 
`some-param`