### PR TITLE
[Feat] Command Implement `ArrayAccsess`

### DIFF
--- a/src/System/Console/Command.php
+++ b/src/System/Console/Command.php
@@ -10,7 +10,7 @@ use System\Text\Str;
  *
  * @property string $name Get argument name
  */
-class Command
+class Command implements \ArrayAccess
 {
     /**
      * Commandline input.
@@ -163,6 +163,32 @@ class Command
     public function __get($name)
     {
         return $this->option($name);
+    }
+
+    /**
+     * @param mixed $offset — Check parse commandline parameters.
+     */
+    public function offsetExists($offset): bool
+    {
+        return array_key_exists($offset, $this->option_mapper);
+    }
+
+    /**
+     * @param mixed $offset — Check parse commandline parameters.
+     */
+    public function offsetGet($offset)
+    {
+        return $this->option($offset);
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        throw new \Exception('Conmmand cant be modify');
+    }
+
+    public function offsetUnset($offset): void
+    {
+        throw new \Exception('Conmmand cant be modify');
     }
 
     /**

--- a/src/System/Console/Command.php
+++ b/src/System/Console/Command.php
@@ -183,12 +183,12 @@ class Command implements \ArrayAccess
 
     public function offsetSet($offset, $value): void
     {
-        throw new \Exception('Conmmand cant be modify');
+        throw new \Exception('Command cant be modify');
     }
 
     public function offsetUnset($offset): void
     {
-        throw new \Exception('Conmmand cant be modify');
+        throw new \Exception('Command cant be modify');
     }
 
     /**

--- a/src/System/Console/Command.php
+++ b/src/System/Console/Command.php
@@ -166,7 +166,7 @@ class Command implements \ArrayAccess
     }
 
     /**
-     * @param mixed $offset — Check parse commandline parameters.
+     * @param mixed $offset — Check parse commandline parameters
      */
     public function offsetExists($offset): bool
     {
@@ -174,7 +174,7 @@ class Command implements \ArrayAccess
     }
 
     /**
-     * @param mixed $offset — Check parse commandline parameters.
+     * @param mixed $offset — Check parse commandline parameters
      */
     public function offsetGet($offset)
     {

--- a/tests/Console/ConsoleParseAsArrayTest.php
+++ b/tests/Console/ConsoleParseAsArrayTest.php
@@ -5,7 +5,6 @@ use System\Console\Command;
 
 class ConsoleParseAsArrayTest extends TestCase
 {
-
     /** @test */
     public function itCanParseNormalCommandWithSpace()
     {

--- a/tests/Console/ConsoleParseAsArrayTest.php
+++ b/tests/Console/ConsoleParseAsArrayTest.php
@@ -39,7 +39,7 @@ class ConsoleParseAsArrayTest extends TestCase
         $argv    = explode(' ', $command);
         $cli     = new Command($argv);
 
-        $this->expectErrorMessage('Conmmand cant be modify');
+        $this->expectErrorMessage('Command cant be modify');
 
         $cli['name'] = 'taylor';
     }
@@ -53,7 +53,7 @@ class ConsoleParseAsArrayTest extends TestCase
         $argv    = explode(' ', $command);
         $cli     = new Command($argv);
 
-        $this->expectErrorMessage('Conmmand cant be modify');
+        $this->expectErrorMessage('Command cant be modify');
 
         unset($cli['name']);
     }

--- a/tests/Console/ConsoleParseAsArrayTest.php
+++ b/tests/Console/ConsoleParseAsArrayTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use System\Console\Command;
+
+class ConsoleParseAsArrayTest extends TestCase
+{
+
+    /** @test */
+    public function itCanParseNormalCommandWithSpace()
+    {
+        $command = 'php cli test --n jhoni -t -s --who-is children';
+        $argv    = explode(' ', $command);
+        $cli     = new Command($argv);
+
+        $this->assertEquals(
+            'test',
+            $cli['name'],
+            'valid parse name: test'
+        );
+
+        $this->assertEquals(
+            'jhoni',
+            $cli['n'],
+            'valid parse from short param with sparte space: --n'
+        );
+
+        $this->assertTrue(
+            isset($cli['who-is']),
+            'valid parse from long param: --who-is'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itWillTrowExcaptionWhenChangeCommand()
+    {
+        $command = 'php cli test --n jhoni -t -s --who-is children';
+        $argv    = explode(' ', $command);
+        $cli     = new Command($argv);
+
+        $this->expectErrorMessage('Conmmand cant be modify');
+
+        $cli['name'] = 'taylor';
+    }
+
+    /**
+     * @test
+     */
+    public function itWillTrowExcaptionWhenUnsetCommand()
+    {
+        $command = 'php cli test --n jhoni -t -s --who-is children';
+        $argv    = explode(' ', $command);
+        $cli     = new Command($argv);
+
+        $this->expectErrorMessage('Conmmand cant be modify');
+
+        unset($cli['name']);
+    }
+}


### PR DESCRIPTION
`Command::class` implement array access. 
access from array
```php
// argv: php cli --some-text hello

// without array access
$cmd->__get('some-text'); 

// with array access
$cmd['some-text'];
```

both can be use to get 'hello' from `argv` command input
