### PR TITLE
[Fix] Return native static type in php 7.4

### DIFF
--- a/src/System/Http/Request.php
+++ b/src/System/Http/Request.php
@@ -163,6 +163,8 @@ class Request implements \ArrayAccess, \IteratorAggregate
      * @param array<string, string>|null $cookies
      * @param array<string, string>|null $files
      * @param array<string, string>|null $headers
+     *
+     * @return static
      */
     public function duplicate(
         array $query = null,
@@ -171,7 +173,7 @@ class Request implements \ArrayAccess, \IteratorAggregate
         array $cookies = null,
         array $files = null,
         array $headers = null
-    ): static {
+    ) {
         $dupplicate = clone $this;
 
         if (null !== $query) {


### PR DESCRIPTION
- php 7.4 doest support native return static type