### PR TITLE
[Refactor] Flush with `flush()` after `closeOutputBuffers`

### DIFF
--- a/src/System/Http/Response.php
+++ b/src/System/Http/Response.php
@@ -210,6 +210,7 @@ class Response
 
         if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
             static::closeOutputBuffers(0, true);
+            flush();
 
             return $this;
         }


### PR DESCRIPTION
inspire by [Flush with flush() after ob_end_flush()](https://github.com/symfony/symfony/commit/118acea77a24c20dc8fd13f6ddefba0f85c77ca8) in Symfony response.