### PR TITLE
feat: templator multy section

### DIFF
--- a/src/System/View/Templator/SectionTemplator.php
+++ b/src/System/View/Templator/SectionTemplator.php
@@ -49,7 +49,7 @@ class SectionTemplator extends AbstractTemplatorParse
                     }
                 }
 
-                return true;
+                return '';
             },
             $template
         );

--- a/src/System/View/Templator/SectionTemplator.php
+++ b/src/System/View/Templator/SectionTemplator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace System\View\Templator;
 
+use System\Text\Str;
 use System\View\AbstractTemplatorParse;
 
 class SectionTemplator extends AbstractTemplatorParse
@@ -34,6 +35,22 @@ class SectionTemplator extends AbstractTemplatorParse
         $template = preg_replace_callback(
             '/{%\s*section\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)\s*%}(.*?){%\s*endsection\s*%}/s',
             fn ($matches) => $this->sections[$matches[1]] = trim($matches[2]),
+            $template
+        );
+
+        $template = preg_replace_callback(
+            '/{%\s*sections\s*\\s*%}(.*?){%\s*endsections\s*%}/s',
+            function ($matches) {
+                $lines = explode("\n", $matches[1]);
+                foreach ($lines as $line) {
+                    if (Str::contains($line, ':')) {
+                        $current                           = explode(':', trim($line));
+                        $this->sections[trim($current[0])] = trim($current[1]);
+                    }
+                }
+
+                return true;
+            },
             $template
         );
 

--- a/tests/View/Templator/SlotTest.php
+++ b/tests/View/Templator/SlotTest.php
@@ -51,4 +51,20 @@ final class SlotTest extends TestCase
         $out       = $templator->templates('{% extend(\'section.template\') %} {% section(\'title\', \'<script>alert(1)</script>\') %}');
         $this->assertEquals('<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>', trim($out));
     }
+
+    /**
+     * @test
+     */
+    public function itCanRenderMultySection()
+    {
+        $templator = new Templator(__DIR__ . '/view/', __DIR__);
+        $out       = $templator->templates('
+            {% extend(\'section.template\') %}
+
+            {% sections %}
+            title : <strong>taylor</strong>
+            {% endsections %}
+        ');
+        $this->assertEquals('<p><strong>taylor</strong></p>', trim($out));
+    }
 }


### PR DESCRIPTION
uses,
```php
{% extend(\'section.template\') %}

{% sections %}
title: taylor
language: php
{% endsections %}
```