### PR TITLE
refactor: load config using `Util::loadCommandFromConfig()`

### DIFF
--- a/src/System/Integrate/Console/HelpCommand.php
+++ b/src/System/Integrate/Console/HelpCommand.php
@@ -8,7 +8,6 @@ use System\Console\Command;
 use System\Console\Style\Style;
 use System\Console\Traits\PrintHelpTrait;
 use System\Integrate\Application;
-use System\Integrate\ConfigRepository;
 use System\Integrate\ValueObjects\CommandMap;
 use System\Text\Str;
 
@@ -261,9 +260,6 @@ class HelpCommand extends Command
      */
     private function commandMaps()
     {
-        return array_map(
-            static fn ($command): CommandMap => new CommandMap($command),
-            Application::getIntance()[ConfigRepository::class]->get('commands', [])
-        );
+        return Util::loadCommandFromConfig(Application::getIntance());
     }
 }

--- a/src/System/Integrate/Console/Karnel.php
+++ b/src/System/Integrate/Console/Karnel.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace System\Integrate\Console;
 
-use DI\Container;
 use System\Console\Style\Style;
 use System\Integrate\Application;
 use System\Integrate\Bootstrap\BootProviders;
 use System\Integrate\Bootstrap\ConfigProviders;
 use System\Integrate\Bootstrap\RegisterProviders;
-use System\Integrate\ConfigRepository;
 use System\Integrate\ValueObjects\CommandMap;
 
 class Karnel
@@ -168,13 +166,10 @@ class Karnel
     /**
      * Command route.
      *
-     * @return \System\Integrate\ValueObjects\CommandMap[]
+     * @return CommandMap[]
      */
-    protected function commands()
+    protected function commands(): array
     {
-        return array_map(
-            static fn ($command): CommandMap => new CommandMap($command),
-            $this->app[ConfigRepository::class]->get('commands', [])
-        );
+        return Util::loadCommandFromConfig($this->app);
     }
 }

--- a/src/System/Integrate/Console/Util.php
+++ b/src/System/Integrate/Console/Util.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace System\Integrate\Console;
+
+use System\Integrate\Application;
+use System\Integrate\ConfigRepository;
+use System\Integrate\ValueObjects\CommandMap;
+
+final class Util
+{
+    /**
+     * Convert command from array to CommandMap.
+     *
+     * @return CommandMap[]
+     */
+    public static function loadCommandFromConfig(Application $app): array
+    {
+        $command_map = [];
+        foreach ($app[ConfigRepository::class]->get('commands', []) as $commands) {
+            foreach ($commands as $command) {
+                $command_map[] = new CommandMap($command);
+            }
+        }
+
+        return $command_map;
+    }
+}

--- a/tests/Integrate/Commands/HelpCommandsTest.php
+++ b/tests/Integrate/Commands/HelpCommandsTest.php
@@ -16,7 +16,7 @@ final class HelpCommandsTest extends CommandTest
     {
         parent::setUp();
         $this->app->set('config', fn () => new ConfigRepository([
-            'commands' => $this->command,
+            'commands' => [$this->command],
         ]));
     }
 

--- a/tests/Integrate/Console/KarnelTest.php
+++ b/tests/Integrate/Console/KarnelTest.php
@@ -226,7 +226,7 @@ final class KarnelTest extends TestCase
 
 class NormalCommand extends Karnel
 {
-    protected function commands()
+    protected function commands(): array
     {
         return [
             // olr style


### PR DESCRIPTION
- load command config now wrap in array (no need array merge), so this util use for flatten wrapper array