### PR TITLE
fix: change typo method name

### DIFF
--- a/src/System/Collection/AbstractCollectionImmutable.php
+++ b/src/System/Collection/AbstractCollectionImmutable.php
@@ -203,7 +203,7 @@ abstract class AbstractCollectionImmutable implements CollectionInterface
     /**
      * @return $this
      */
-    public function dumb(): self
+    public function dump(): self
     {
         var_dump($this->collection);
 


### PR DESCRIPTION
why we chosed to raname without depracted. this method call for dump data (uder dev) its not effect in production.