### PR TITLE
refactor: change cache facade accessor

### DIFF
--- a/src/System/Support/Facades/Cache.php
+++ b/src/System/Support/Facades/Cache.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace System\Support\Facades;
 
-use System\Cache\CacheManager;
-
 /**
  * @method static self                         setDefaultDriver(\System\Cache\CacheInterface $driver)
  * @method static self                         setDriver(string $driver_name, \System\Cache\CacheInterface $driver)
@@ -26,6 +24,6 @@ final class Cache extends Facade
 {
     protected static function getAccessor()
     {
-        return CacheManager::class;
+        return 'cache';
     }
 }


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **No**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues | |

------
Change facade accesor for `Cache` to `cache` instead of `CacheManager::class`.
