### PR TITLE
refactor: change global __get return form `source()` to `all()`

### DIFF
--- a/src/System/Http/Request.php
+++ b/src/System/Http/Request.php
@@ -610,7 +610,7 @@ class Request implements \ArrayAccess, \IteratorAggregate
      */
     public function __get($key)
     {
-        return $this->source()->get($key);
+        return $this->all()[$key] ?? null;
     }
 
     /**


### PR DESCRIPTION
not BC but improvement `source()` union of `all()`

| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **No**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues | |

------
Not BC but improvement `source()` union of `all()`.
