### PR TITLE
feat: cache Templator when using `file_get_contents()`

### DIFF
--- a/src/System/View/InteractWithCacheTrait.php
+++ b/src/System/View/InteractWithCacheTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace System\View;
+
+trait InteractWithCacheTrait
+{
+    /**
+     * Get contents using cache first.
+     */
+    private function getContents(string $file_name): string
+    {
+        if (false === array_key_exists($file_name, self::$cache)) {
+            self::$cache[$file_name] = file_get_contents($file_name);
+        }
+
+        return self::$cache[$file_name];
+    }
+}

--- a/src/System/View/Templator/IncludeTemplator.php
+++ b/src/System/View/Templator/IncludeTemplator.php
@@ -5,10 +5,20 @@ declare(strict_types=1);
 namespace System\View\Templator;
 
 use System\View\AbstractTemplatorParse;
+use System\View\InteractWithCacheTrait;
 
 class IncludeTemplator extends AbstractTemplatorParse
 {
+    use InteractWithCacheTrait;
+
     private int $maks_dept = 5;
+
+    /**
+     * File get content cached.
+     *
+     * @var array<string, string>
+     */
+    private static array $cache = [];
 
     public function maksDept(int $maks_dept): self
     {
@@ -19,6 +29,8 @@ class IncludeTemplator extends AbstractTemplatorParse
 
     public function parse(string $template): string
     {
+        self::$cache = [];
+
         return preg_replace_callback(
             '/{%\s*include\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)\s*%}/',
             function ($matches) {
@@ -27,7 +39,7 @@ class IncludeTemplator extends AbstractTemplatorParse
                 }
 
                 $templatePath     = $this->finder->find($matches[1]);
-                $includedTemplate = file_get_contents($templatePath);
+                $includedTemplate = $this->getContents($templatePath);
 
                 if ($this->maks_dept === 0) {
                     return $includedTemplate;

--- a/src/System/View/Templator/SectionTemplator.php
+++ b/src/System/View/Templator/SectionTemplator.php
@@ -6,14 +6,26 @@ namespace System\View\Templator;
 
 use System\Text\Str;
 use System\View\AbstractTemplatorParse;
+use System\View\InteractWithCacheTrait;
 
 class SectionTemplator extends AbstractTemplatorParse
 {
+    use InteractWithCacheTrait;
+
     /** @var array<string, mixed> */
     private $sections     = [];
 
+    /**
+     * File get content cached.
+     *
+     * @var array<string, string>
+     */
+    private static array $cache = [];
+
     public function parse(string $template): string
     {
+        self::$cache = [];
+
         preg_match('/{%\s*extend\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)\s*%}/', $template, $matches_layout);
         if (!array_key_exists(1, $matches_layout)) {
             return $template;
@@ -24,7 +36,7 @@ class SectionTemplator extends AbstractTemplatorParse
         }
 
         $templatePath = $this->finder->find($matches_layout[1]);
-        $layout       = file_get_contents($templatePath);
+        $layout       = $this->getContents($templatePath);
 
         $template = preg_replace_callback(
             '/{%\s*section\s*\(\s*[\'"]([^\'"]+)[\'"]\s*,\s*[\'"]([^\'"]+)[\'"]\s*\)\s*%}/s',


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **No**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **No**                                              |
| Improvement| **Yes**|
| Fixed issues | |

------
Improve templator when getting file recursing by using static cache.
