### PR TITLE
fix: prevent cache `FileStorage::class` delete gitignore

### DIFF
--- a/src/System/Cache/Storage/FileStorage.php
+++ b/src/System/Cache/Storage/FileStorage.php
@@ -103,8 +103,14 @@ class FileStorage implements CacheInterface
         );
 
         foreach ($files as $fileinfo) {
+            $filePath = $fileinfo->getRealPath();
+
+            if (basename($filePath) === '.gitignore') {
+                continue;
+            }
+
             $action = $fileinfo->isDir() ? 'rmdir' : 'unlink';
-            $action($fileinfo->getRealPath());
+            $action($filePath);
         }
 
         return true;


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **Yes**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues | |

------
Prevent cache `FileStorage::class` delete gitignore when call `clear` method.
