### PR TITLE
feat: add missing aplication configuation

### DIFF
--- a/src/System/Integrate/Application.php
+++ b/src/System/Integrate/Application.php
@@ -295,6 +295,8 @@ final class Application extends Container
             'APP_KEY'               => '',
             'ENVIRONMENT'           => 'dev',
             'APP_DEBUG'             => 'false',
+            'BCRYPT_ROUNDS'         => 12,
+            'CACHE_STORE'           => 'file',
 
             'COMMAND_PATH'          => DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'Commands' . DIRECTORY_SEPARATOR,
             'CONTROLLER_PATH'       => DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'Controllers' . DIRECTORY_SEPARATOR,

--- a/tests/Integrate/ApplicationTest.php
+++ b/tests/Integrate/ApplicationTest.php
@@ -44,7 +44,7 @@ class ApplicationTest extends TestCase
         $app = new Application('/');
 
         $app->loadConfig(new ConfigRepository($app->defaultConfigs()));
-        /** @var Config */
+        /** @var System\Integrate\ConfigRepository */
         $config = $app->get('config');
 
         $this->assertEquals($this->defaultConfigs(), $config->toArray());
@@ -288,6 +288,8 @@ class ApplicationTest extends TestCase
             'APP_KEY'               => '',
             'ENVIRONMENT'           => 'dev',
             'APP_DEBUG'             => 'false',
+            'BCRYPT_ROUNDS'         => 12,
+            'CACHE_STORE'           => 'file',
 
             'COMMAND_PATH'          => DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'Commands' . DIRECTORY_SEPARATOR,
             'CONTROLLER_PATH'       => DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'Controllers' . DIRECTORY_SEPARATOR,

--- a/tests/Integrate/ApplicationTest.php
+++ b/tests/Integrate/ApplicationTest.php
@@ -44,7 +44,7 @@ class ApplicationTest extends TestCase
         $app = new Application('/');
 
         $app->loadConfig(new ConfigRepository($app->defaultConfigs()));
-        /** @var System\Integrate\ConfigRepository */
+        /** @var ConfigRepository */
         $config = $app->get('config');
 
         $this->assertEquals($this->defaultConfigs(), $config->toArray());


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **No**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues |  |

------
php-library have two feature witch require some configuration. password manager need bcrypt round (2 is default). cache manager file storage.

- add `bcrypt_rounds` and `cache_store`
