### PR TITLE
fix: allow set driver using closure

### DIFF
--- a/src/System/Cache/CacheManager.php
+++ b/src/System/Cache/CacheManager.php
@@ -47,12 +47,12 @@ class CacheManager implements CacheInterface
             throw new \Exception("Can use driver {$driver_name}.");
         }
 
-        return $driver;
+        return $this->driver[$driver_name] = $driver;
     }
 
     public function driver(?string $driver_name = null): CacheInterface
     {
-        if (array_key_exists($driver_name, $this->driver)) {
+        if (isset($this->driver[$driver_name])) {
             return $this->getDriver($driver_name);
         }
 

--- a/src/System/Cache/CacheManager.php
+++ b/src/System/Cache/CacheManager.php
@@ -35,7 +35,7 @@ class CacheManager implements CacheInterface
         return $this;
     }
 
-    public function getDriver(string $driver_name): CacheInterface
+    private function resolve(string $driver_name): CacheInterface
     {
         $driver = $this->driver[$driver_name];
 
@@ -53,7 +53,7 @@ class CacheManager implements CacheInterface
     public function driver(?string $driver_name = null): CacheInterface
     {
         if (isset($this->driver[$driver_name])) {
-            return $this->getDriver($driver_name);
+            return $this->resolve($driver_name);
         }
 
         return $this->default_driver;

--- a/src/System/Cache/CacheManager.php
+++ b/src/System/Cache/CacheManager.php
@@ -8,7 +8,7 @@ use System\Cache\Storage\ArrayStorage;
 
 class CacheManager implements CacheInterface
 {
-    /** @var array<string, CacheInterface> */
+    /** @var array<string, CacheInterface|\Closure(): CacheInterface> */
     private $driver = [];
 
     private CacheInterface $default_driver;
@@ -25,17 +25,35 @@ class CacheManager implements CacheInterface
         return $this;
     }
 
-    public function setDriver(string $driver_name, CacheInterface $driver): self
+    /**
+     * @param CacheInterface|\Closure(): CacheInterface $driver
+     */
+    public function setDriver(string $driver_name, $driver): self
     {
         $this->driver[$driver_name] = $driver;
 
         return $this;
     }
 
-    public function driver(?string $driver = null): CacheInterface
+    public function getDriver(string $driver_name): CacheInterface
     {
-        if (array_key_exists($driver, $this->driver)) {
-            return $this->driver[$driver];
+        $driver = $this->driver[$driver_name];
+
+        if (\is_callable($driver)) {
+            $driver = $driver();
+        }
+
+        if (null === $driver) {
+            throw new \Exception("Can use driver {$driver_name}.");
+        }
+
+        return $driver;
+    }
+
+    public function driver(?string $driver_name = null): CacheInterface
+    {
+        if (array_key_exists($driver_name, $this->driver)) {
+            return $this->getDriver($driver_name);
         }
 
         return $this->default_driver;

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -20,4 +20,14 @@ class CacheManagerTest extends TestCase
         $this->assertTrue($cache->set('key1', 'value1'));
         $this->assertEquals('value1', $cache->get('key1'));
     }
+
+    public function testDriver(): void
+    {
+        $cache = new CacheManager();
+        $cache->setDriver('array2', fn (): CacheInterface => new ArrayStorage());
+        $this->assertInstanceOf(CacheInterface::class, $cache->driver('array'));
+
+        $this->assertTrue($cache->set('key1', 'value1'));
+        $this->assertEquals('value1', $cache->get('key1'));
+    }
 }

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -25,9 +25,9 @@ class CacheManagerTest extends TestCase
     {
         $cache = new CacheManager();
         $cache->setDriver('array2', fn (): CacheInterface => new ArrayStorage());
-        $this->assertInstanceOf(CacheInterface::class, $cache->driver('array'));
+        $this->assertInstanceOf(CacheInterface::class, $cache->driver('array2'));
 
-        $this->assertTrue($cache->set('key1', 'value1'));
-        $this->assertEquals('value1', $cache->get('key1'));
+        $this->assertTrue($cache->driver('array2')->set('key1', 'value1'));
+        $this->assertEquals('value1', $cache->driver('array2')->get('key1'));
     }
 }


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **Yes**                                              |
| New feature? | **Yes**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues | |

------
Allowing lazy load driver without initial driver, by adding closure driver it will load if needed (without initial first).
