### PR TITLE
fix: correct age calculation and improve code formatting

### DIFF
--- a/src/System/Time/Now.php
+++ b/src/System/Time/Now.php
@@ -62,7 +62,7 @@ class Now
         if (null !== $time_zone) {
             $time_zone = new \DateTimeZone($time_zone);
         }
-        $this->date = new \DateTime($date_format, $time_zone);
+        $this->date     = new \DateTime($date_format, $time_zone);
 
         $this->refresh();
     }
@@ -126,8 +126,9 @@ class Now
         $this->timeZone  = $this->date->format('e');
         $this->shortDay  = $this->date->format('D');
 
-        $age       = time() - $this->date->getTimestamp();
-        $this->age = abs(floor($age / (365 * 60 * 60 * 24)));
+        $now       = new \DateTime('now', new \DateTimeZone($this->timeZone));
+        $interval  = $now->diff($this->date);
+        $this->age = $interval->y;
     }
 
     private function current(string $format, int $timestamp): string

--- a/tests/Time/TimeTravelTest.php
+++ b/tests/Time/TimeTravelTest.php
@@ -155,9 +155,11 @@ final class TimeTravelTest extends TestCase
      */
     public function itCorrectAge(): void
     {
-        $now = new Now('01/01/2000');
+        $now         = new Now('01/01/2000');
+        $currentYear = (int) date('Y');
+        $expectedAge = $currentYear - 2000;
         $this->assertSame(
-            24.0,
+            $expectedAge,
             $now->age,
             'the age must equal'
         );


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **Yes**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **Yes**                                              |
| Fixed issues |  |

------
Correct the age calculation logic to accurately reflect the difference in years and enhance code formatting for better readability. bc return integer instead of float. 