### PR TITLE
Refactor/remove backtick query builder

### DIFF
--- a/src/System/Database/MyModel/Model.php
+++ b/src/System/Database/MyModel/Model.php
@@ -180,7 +180,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     public function getter(string $key, $default = null)
     {
         if (array_key_exists($key, $this->stash)) {
-            throw new \Exception("Cant read this colum {$key}");
+            throw new \Exception("Cant read this column `{$key}`.");
         }
 
         return $this->first()[$key] ?? $default;
@@ -413,7 +413,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
         foreach (array_keys($this->columns) as $key) {
             if (!array_key_exists($column, $this->columns[$key])
             || !array_key_exists($column, $this->fresh[$key])) {
-                throw new \Exception("Column {$column} is not in table {$this->table_name}");
+                throw new \Exception("Column {$column} is not in table `{$this->table_name}`.");
             }
 
             if (false === ($this->columns[$key][$column] === $this->fresh[$key][$column])) {
@@ -550,7 +550,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     {
         $order = 0 === $order_using ? 'ASC' : 'DESC';
         $belong_to ??= $this->table_name;
-        $this->sort_order = "ORDER BY $belong_to.$column_name $order";
+        $this->sort_order = "ORDER BY {$belong_to}.{$column_name} {$order}";
 
         return $this;
     }

--- a/src/System/Database/MyModel/Model.php
+++ b/src/System/Database/MyModel/Model.php
@@ -180,7 +180,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     public function getter(string $key, $default = null)
     {
         if (array_key_exists($key, $this->stash)) {
-            throw new \Exception("Cant read this colum `{$key}`");
+            throw new \Exception("Cant read this colum {$key}");
         }
 
         return $this->first()[$key] ?? $default;
@@ -413,7 +413,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
         foreach (array_keys($this->columns) as $key) {
             if (!array_key_exists($column, $this->columns[$key])
             || !array_key_exists($column, $this->fresh[$key])) {
-                throw new \Exception("Column `{$column}` is not in table `{$this->table_name}`");
+                throw new \Exception("Column {$column} is not in table {$this->table_name}");
             }
 
             if (false === ($this->columns[$key][$column] === $this->fresh[$key][$column])) {
@@ -550,7 +550,7 @@ class Model implements \ArrayAccess, \IteratorAggregate
     {
         $order = 0 === $order_using ? 'ASC' : 'DESC';
         $belong_to ??= $this->table_name;
-        $this->sort_order = "ORDER BY `$belong_to`.`$column_name` $order";
+        $this->sort_order = "ORDER BY $belong_to.$column_name $order";
 
         return $this;
     }

--- a/src/System/Database/MyQuery/Delete.php
+++ b/src/System/Database/MyQuery/Delete.php
@@ -28,7 +28,7 @@ class Delete extends Execute
     {
         $where = $this->getWhere();
 
-        $this->_query = "DELETE FROM $this->_table $where";
+        $this->_query = "DELETE FROM {$this->_table} {$where}";
 
         return $this->_query;
     }

--- a/src/System/Database/MyQuery/Delete.php
+++ b/src/System/Database/MyQuery/Delete.php
@@ -28,7 +28,7 @@ class Delete extends Execute
     {
         $where = $this->getWhere();
 
-        $this->_query = "DELETE FROM `$this->_table` $where";
+        $this->_query = "DELETE FROM $this->_table $where";
 
         return $this->_query;
     }

--- a/src/System/Database/MyQuery/InnerQuery.php
+++ b/src/System/Database/MyQuery/InnerQuery.php
@@ -17,7 +17,7 @@ final class InnerQuery implements \Stringable
 
     public function getAlias(): string
     {
-        return "{$this->table}";
+        return $this->table;
     }
 
     /** @return Bind[]  */

--- a/src/System/Database/MyQuery/InnerQuery.php
+++ b/src/System/Database/MyQuery/InnerQuery.php
@@ -17,7 +17,7 @@ final class InnerQuery implements \Stringable
 
     public function getAlias(): string
     {
-        return "`{$this->table}`";
+        return "{$this->table}";
     }
 
     /** @return Bind[]  */

--- a/src/System/Database/MyQuery/Insert.php
+++ b/src/System/Database/MyQuery/Insert.php
@@ -77,7 +77,7 @@ class Insert extends Execute
         $stringBinds  = implode(', ', $strings_binds);
         $stringColumn = implode(', ', $columns);
 
-        $this->_query = "INSERT INTO `$this->_table` ($stringColumn) VALUES $stringBinds";
+        $this->_query = "INSERT INTO $this->_table ($stringColumn) VALUES $stringBinds";
 
         return $this->_query;
     }

--- a/src/System/Database/MyQuery/Insert.php
+++ b/src/System/Database/MyQuery/Insert.php
@@ -77,7 +77,7 @@ class Insert extends Execute
         $stringBinds  = implode(', ', $strings_binds);
         $stringColumn = implode(', ', $columns);
 
-        $this->_query = "INSERT INTO $this->_table ($stringColumn) VALUES $stringBinds";
+        $this->_query = "INSERT INTO {$this->_table} ({$stringColumn}) VALUES {$stringBinds}";
 
         return $this->_query;
     }

--- a/src/System/Database/MyQuery/Query.php
+++ b/src/System/Database/MyQuery/Query.php
@@ -177,7 +177,7 @@ abstract class Query
     protected function splitFilters(array $filters): string
     {
         $query      = [];
-        $table_name = null === $this->_sub_query ? "{$this->_table}" : $this->_sub_query->getAlias();
+        $table_name = null === $this->_sub_query ? $this->_table : $this->_sub_query->getAlias();
         foreach ($filters['filters'] as $fieldName => $fieldValue) {
             $value        = $fieldValue['value'];
             $comparation  = $fieldValue['comparation'];

--- a/src/System/Database/MyQuery/Query.php
+++ b/src/System/Database/MyQuery/Query.php
@@ -177,7 +177,7 @@ abstract class Query
     protected function splitFilters(array $filters): string
     {
         $query      = [];
-        $table_name = null === $this->_sub_query ? "`{$this->_table}`" : $this->_sub_query->getAlias();
+        $table_name = null === $this->_sub_query ? "{$this->_table}" : $this->_sub_query->getAlias();
         foreach ($filters['filters'] as $fieldName => $fieldValue) {
             $value        = $fieldValue['value'];
             $comparation  = $fieldValue['comparation'];

--- a/src/System/Database/MyQuery/Select.php
+++ b/src/System/Database/MyQuery/Select.php
@@ -34,11 +34,6 @@ final class Select extends Fetch
             $this->_binds = $table_name->getBind();
         }
 
-        // defaul query
-        if (count($this->_column) > 1) {
-            $this->_column = array_map(fn ($e) => "$e", $this->_column);
-        }
-
         $column       = implode(', ', $columns_name);
         $this->_query = $options['query'] ?? "SELECT {$column} FROM { $this->_sub_query}";
     }
@@ -49,7 +44,7 @@ final class Select extends Fetch
     }
 
     /**
-     * Instance of Select::class.
+     * Instance of `Select::class`.
      *
      * @param string   $table_name  Table name
      * @param string[] $column_name Selected column

--- a/src/System/Database/MyQuery/Select.php
+++ b/src/System/Database/MyQuery/Select.php
@@ -36,11 +36,11 @@ final class Select extends Fetch
 
         // defaul query
         if (count($this->_column) > 1) {
-            $this->_column = array_map(fn ($e) => "`$e`", $this->_column);
+            $this->_column = array_map(fn ($e) => "$e", $this->_column);
         }
 
         $column       = implode(', ', $columns_name);
-        $this->_query = $options['query'] ?? "SELECT {$column} FROM `{ $this->_sub_query}`";
+        $this->_query = $options['query'] ?? "SELECT {$column} FROM { $this->_sub_query}";
     }
 
     public function __toString()
@@ -49,7 +49,7 @@ final class Select extends Fetch
     }
 
     /**
-     * Instance of `Select::class`.
+     * Instance of Select::class.
      *
      * @param string   $table_name  Table name
      * @param string[] $column_name Selected column
@@ -171,8 +171,8 @@ final class Select extends Fetch
     public function order(string $column_name, int $order_using = MyQuery::ORDER_ASC, ?string $belong_to = null)
     {
         $order = 0 === $order_using ? 'ASC' : 'DESC';
-        $belong_to ??= null === $this->_sub_query ? "`{$this->_table}`" : $this->_sub_query->getAlias();
-        $this->_sort_order = "ORDER BY $belong_to.`$column_name` $order";
+        $belong_to ??= null === $this->_sub_query ? "{$this->_table}" : $this->_sub_query->getAlias();
+        $this->_sort_order = "ORDER BY $belong_to.$column_name $order";
 
         return $this;
     }

--- a/src/System/Database/MyQuery/Table.php
+++ b/src/System/Database/MyQuery/Table.php
@@ -82,13 +82,13 @@ class Table
     {
         $this->PDO->query(
             'SELECT
-                `COLUMN_NAME`,
-                `COLUMN_TYPE`,
-                `CHARACTER_SET_NAME`,
-                `COLLATION_NAME`,
-                `IS_NULLABLE`,
-                `ORDINAL_POSITION`,
-                `COLUMN_KEY`
+                COLUMN_NAME,
+                COLUMN_TYPE,
+                CHARACTER_SET_NAME,
+                COLLATION_NAME,
+                IS_NULLABLE,
+                ORDINAL_POSITION,
+                COLUMN_KEY
             FROM
                 INFORMATION_SCHEMA.COLUMNS
             WHERE

--- a/src/System/Database/MyQuery/Traits/ConditionTrait.php
+++ b/src/System/Database/MyQuery/Traits/ConditionTrait.php
@@ -75,10 +75,10 @@ trait ConditionTrait
      */
     public function between(string $column_name, $value_1, $value_2)
     {
-        $table_name = null === $this->_sub_query ? "`{$this->_table}`" : $this->_sub_query->getAlias();
+        $table_name = null === $this->_sub_query ? "{$this->_table}" : $this->_sub_query->getAlias();
 
         $this->where(
-            "({$table_name}.`{$column_name}` BETWEEN :b_start AND :b_end)",
+            "({$table_name}.{$column_name} BETWEEN :b_start AND :b_end)",
             []
         );
 
@@ -105,10 +105,10 @@ trait ConditionTrait
             $binder[] = [":in_$key", $bind];
         }
         $bindString = implode(', ', $binds);
-        $table_name = null === $this->_sub_query ? "`{$this->_table}`" : $this->_sub_query->getAlias();
+        $table_name = null === $this->_sub_query ? "{$this->_table}" : $this->_sub_query->getAlias();
 
         $this->where(
-            "({$table_name}.`{$column_name}` IN ({$bindString}))",
+            "({$table_name}.{$column_name} IN ({$bindString}))",
             $binder
         );
 

--- a/src/System/Database/MyQuery/Traits/ConditionTrait.php
+++ b/src/System/Database/MyQuery/Traits/ConditionTrait.php
@@ -75,7 +75,7 @@ trait ConditionTrait
      */
     public function between(string $column_name, $value_1, $value_2)
     {
-        $table_name = null === $this->_sub_query ? "{$this->_table}" : $this->_sub_query->getAlias();
+        $table_name = null === $this->_sub_query ? $this->_table : $this->_sub_query->getAlias();
 
         $this->where(
             "({$table_name}.{$column_name} BETWEEN :b_start AND :b_end)",

--- a/src/System/Database/MyQuery/Update.php
+++ b/src/System/Database/MyQuery/Update.php
@@ -62,7 +62,7 @@ class Update extends Execute
         $setter = [];
         foreach ($this->_binds as $bind) {
             if ($bind->hasColumName()) {
-                $setter[] = '' . $bind->getColumnName() . ' = ' . $bind->getBind();
+                $setter[] = $bind->getColumnName() . ' = ' . $bind->getBind();
             }
         }
 

--- a/src/System/Database/MyQuery/Update.php
+++ b/src/System/Database/MyQuery/Update.php
@@ -62,14 +62,14 @@ class Update extends Execute
         $setter = [];
         foreach ($this->_binds as $bind) {
             if ($bind->hasColumName()) {
-                $setter[] = '`' . $bind->getColumnName() . '` = ' . $bind->getBind();
+                $setter[] = '' . $bind->getColumnName() . ' = ' . $bind->getBind();
             }
         }
 
         // $binds       = array_filter($setter);
         $set_string  = implode(', ', $setter);
 
-        $this->_query = "UPDATE `$this->_table` SET $set_string $where";
+        $this->_query = "UPDATE $this->_table SET $set_string $where";
 
         return $this->_query;
     }

--- a/src/System/Database/MySchema/Table/Alter.php
+++ b/src/System/Database/MySchema/Table/Alter.php
@@ -88,7 +88,7 @@ class Alter extends Query
         $res = [];
 
         foreach ($this->rename_columns as $old => $new) {
-            $res[] = "RENAME COLUMN `{$old}` TO `{$new}`";
+            $res[] = "RENAME COLUMN {$old} TO {$new}";
         }
 
         return $res;
@@ -112,7 +112,7 @@ class Alter extends Query
         $res = [];
 
         foreach ($this->drop_columns as $drop) {
-            $res[] = "DROP COLUMN `{$drop}`";
+            $res[] = "DROP COLUMN {$drop}";
         }
 
         return $res;

--- a/src/System/Database/MySchema/Table/Attributes/Alter/Constraint.php
+++ b/src/System/Database/MySchema/Table/Attributes/Alter/Constraint.php
@@ -10,7 +10,7 @@ class Constraint extends AttributesConstraint
 {
     public function after(string $column): self
     {
-        $this->order = "AFTER `{$column}`";
+        $this->order = "AFTER {$column}";
 
         return $this;
     }

--- a/src/System/Database/MySchema/Table/Attributes/Alter/DataType.php
+++ b/src/System/Database/MySchema/Table/Attributes/Alter/DataType.php
@@ -24,7 +24,7 @@ class DataType
 
     private function query(): string
     {
-        return '`' . $this->name . '` ' . $this->datatype;
+        return $this->name . ' ' . $this->datatype;
     }
 
     // number
@@ -141,7 +141,7 @@ class DataType
 
     public function after(string $column): void
     {
-        $this->datatype = "AFTER `{$column}`";
+        $this->datatype = "AFTER {$column}";
     }
 
     public function first(): void

--- a/src/System/Database/MySchema/Table/Attributes/DataType.php
+++ b/src/System/Database/MySchema/Table/Attributes/DataType.php
@@ -24,7 +24,7 @@ class DataType
 
     private function query(): string
     {
-        return '`' . $this->name . '` ' . $this->datatype;
+        return $this->name . ' ' . $this->datatype;
     }
 
     // number

--- a/src/System/Database/MySchema/Table/Create.php
+++ b/src/System/Database/MySchema/Table/Create.php
@@ -126,7 +126,7 @@ class Create extends Query
             return [''];
         }
 
-        $primaryKeys = array_map(fn ($primaryKey) => "{$primaryKey}", $this->primaryKeys);
+        $primaryKeys = array_map(fn ($primaryKey) => $primaryKey, $this->primaryKeys);
         $primaryKeys = implode(', ', $primaryKeys);
 
         return ["PRIMARY KEY ({$primaryKeys})"];
@@ -139,8 +139,7 @@ class Create extends Query
             return [''];
         }
 
-        $uniques = array_map(fn ($uniques) => "{$uniques}", $this->uniques);
-        $uniques = implode(', ', $uniques);
+        $uniques = implode(', ', $this->uniques);
 
         return ["UNIQUE ({$uniques})"];
     }

--- a/src/System/Database/MySchema/Table/Create.php
+++ b/src/System/Database/MySchema/Table/Create.php
@@ -126,7 +126,7 @@ class Create extends Query
             return [''];
         }
 
-        $primaryKeys = array_map(fn ($primaryKey) => "`{$primaryKey}`", $this->primaryKeys);
+        $primaryKeys = array_map(fn ($primaryKey) => "{$primaryKey}", $this->primaryKeys);
         $primaryKeys = implode(', ', $primaryKeys);
 
         return ["PRIMARY KEY ({$primaryKeys})"];
@@ -139,7 +139,7 @@ class Create extends Query
             return [''];
         }
 
-        $uniques = array_map(fn ($uniques) => "`{$uniques}`", $this->uniques);
+        $uniques = array_map(fn ($uniques) => "{$uniques}", $this->uniques);
         $uniques = implode(', ', $uniques);
 
         return ["UNIQUE ({$uniques})"];

--- a/tests/DataBase/BaseConnection.php
+++ b/tests/DataBase/BaseConnection.php
@@ -43,11 +43,11 @@ abstract class BaseConnection extends TestCase
     {
         return $this
            ->pdo
-           ->query('CREATE TABLE `users` (
-                `user`      varchar(32)  NOT NULL,
-                `password`  varchar(500) NOT NULL,
-                `stat`      int(2)       NOT NULL,
-                PRIMARY KEY (`user`)
+           ->query('CREATE TABLE users (
+                user      varchar(32)  NOT NULL,
+                password  varchar(500) NOT NULL,
+                stat      int(2)       NOT NULL,
+                PRIMARY KEY (user)
             )')
            ->execute();
     }

--- a/tests/DataBase/Model/BaseModelTest.php
+++ b/tests/DataBase/Model/BaseModelTest.php
@@ -43,11 +43,11 @@ final class BaseModelTest extends BaseConnection
     {
         return $this
            ->pdo
-           ->query('CREATE TABLE `profiles` (
-                `user`      varchar(32)  NOT NULL,
-                `name`      varchar(100) NOT NULL,
-                `gender`    varchar(10) NOT NULL,
-                PRIMARY KEY (`user`)
+           ->query('CREATE TABLE profiles (
+                user      varchar(32)  NOT NULL,
+                name      varchar(100) NOT NULL,
+                gender    varchar(10) NOT NULL,
+                PRIMARY KEY (user)
             )')
            ->execute();
     }
@@ -63,12 +63,12 @@ final class BaseModelTest extends BaseConnection
     {
         return $this
            ->pdo
-           ->query('CREATE TABLE `orders` (
-                `id`   varchar(3)  NOT NULL,
-                `user` varchar(32)  NOT NULL,
-                `name` varchar(100) NOT NULL,
-                `type` varchar(30) NOT NULL,
-                PRIMARY KEY (`id`)
+           ->query('CREATE TABLE orders (
+                id   varchar(3)  NOT NULL,
+                user varchar(32)  NOT NULL,
+                name varchar(100) NOT NULL,
+                type varchar(30) NOT NULL,
+                PRIMARY KEY (id)
             )')
            ->execute();
     }

--- a/tests/DataBase/Model/BaseMultyModelTest.php
+++ b/tests/DataBase/Model/BaseMultyModelTest.php
@@ -55,11 +55,11 @@ final class BaseMultyModelTest extends BaseConnection
     {
         return $this
            ->pdo
-           ->query('CREATE TABLE `profiles` (
-                `user`      varchar(32)  NOT NULL,
-                `name`      varchar(100) NOT NULL,
-                `gender`    varchar(10) NOT NULL,
-                PRIMARY KEY (`user`)
+           ->query('CREATE TABLE profiles (
+                user      varchar(32)  NOT NULL,
+                name      varchar(100) NOT NULL,
+                gender    varchar(10) NOT NULL,
+                PRIMARY KEY (user)
             )')
            ->execute();
     }
@@ -75,12 +75,12 @@ final class BaseMultyModelTest extends BaseConnection
     {
         return $this
            ->pdo
-           ->query('CREATE TABLE `orders` (
-                `id`   varchar(3)  NOT NULL,
-                `user` varchar(32)  NOT NULL,
-                `name` varchar(100) NOT NULL,
-                `type` varchar(30) NOT NULL,
-                PRIMARY KEY (`id`)
+           ->query('CREATE TABLE orders (
+                id   varchar(3)  NOT NULL,
+                user varchar(32)  NOT NULL,
+                name varchar(100) NOT NULL,
+                type varchar(30) NOT NULL,
+                PRIMARY KEY (id)
             )')
            ->execute();
     }

--- a/tests/DataBase/Model/CostumeModelTest.php
+++ b/tests/DataBase/Model/CostumeModelTest.php
@@ -54,12 +54,12 @@ final class CostumeModelTest extends BaseConnection
     {
         return $this
            ->pdo
-           ->query('CREATE TABLE `profiles` (
-                `user`      varchar(32)  NOT NULL,
-                `name`      varchar(100) NOT NULL,
-                `gender`    varchar(10) NOT NULL,
-                `age`       int(3) NOT NULL,
-                PRIMARY KEY (`user`)
+           ->query('CREATE TABLE profiles (
+                user      varchar(32)  NOT NULL,
+                name      varchar(100) NOT NULL,
+                gender    varchar(10) NOT NULL,
+                age       int(3) NOT NULL,
+                PRIMARY KEY (user)
             )')
            ->execute();
     }

--- a/tests/DataBase/MySchemaTest.php
+++ b/tests/DataBase/MySchemaTest.php
@@ -35,7 +35,7 @@ final class MySchemaTest extends \RealDatabaseConnectionTest
     public function itCanExecuteUsingRawQuery()
     {
         $schema = new MySchema($this->pdo_schema);
-        $raw    = $schema->raw('ALTER TABLE testing_db.users MODIFY COLUMN `user` varchar(20), ADD `status` int(3), DROP COLUMN `stat`');
+        $raw    = $schema->raw('ALTER TABLE testing_db.users MODIFY COLUMN user varchar(20), ADD status int(3), DROP COLUMN stat');
 
         $this->assertTrue($raw->execute());
     }

--- a/tests/DataBase/Query/DeleteTest.php
+++ b/tests/DataBase/Query/DeleteTest.php
@@ -17,12 +17,12 @@ final class DeleteTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end)',
+            'DELETE FROM test WHERE (test.column_1 BETWEEN :b_start AND :b_end)',
             $delete->__toString()
         );
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE (`test`.`column_1` BETWEEN 1 AND 100)',
+            'DELETE FROM test WHERE (test.column_1 BETWEEN 1 AND 100)',
             $delete->queryBind()
         );
     }
@@ -36,12 +36,12 @@ final class DeleteTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE ( (`test`.column_1 = :column_1) )',
+            'DELETE FROM test WHERE ( (test.column_1 = :column_1) )',
             $delete->__toString()
         );
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE ( (`test`.column_1 = 100) )',
+            'DELETE FROM test WHERE ( (test.column_1 = 100) )',
             $delete->queryBind()
         );
     }
@@ -55,12 +55,12 @@ final class DeleteTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE ( (`test`.column_1 = :column_1) )',
+            'DELETE FROM test WHERE ( (test.column_1 = :column_1) )',
             $delete->__toString()
         );
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE ( (`test`.column_1 = 100) )',
+            'DELETE FROM test WHERE ( (test.column_1 = 100) )',
             $delete->queryBind()
         );
     }
@@ -74,12 +74,12 @@ final class DeleteTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE (`test`.`column_1` IN (:in_0, :in_1))',
+            'DELETE FROM test WHERE (test.column_1 IN (:in_0, :in_1))',
             $delete->__toString()
         );
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE (`test`.`column_1` IN (1, 2))',
+            'DELETE FROM test WHERE (test.column_1 IN (1, 2))',
             $delete->queryBind()
         );
     }
@@ -93,12 +93,12 @@ final class DeleteTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE ( (`test`.column_1 LIKE :column_1) )',
+            'DELETE FROM test WHERE ( (test.column_1 LIKE :column_1) )',
             $delete->__toString()
         );
 
         $this->assertEquals(
-            "DELETE FROM `test` WHERE ( (`test`.column_1 LIKE 'test') )",
+            "DELETE FROM test WHERE ( (test.column_1 LIKE 'test') )",
             $delete->queryBind()
         );
     }
@@ -112,13 +112,13 @@ final class DeleteTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE a < :a OR b > :b',
+            'DELETE FROM test WHERE a < :a OR b > :b',
             $delete->__toString(),
             'update with where statment is like'
         );
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE a < 1 OR b > 2',
+            'DELETE FROM test WHERE a < 1 OR b > 2',
             $delete->queryBind(),
             'update with where statment is like'
         );
@@ -134,13 +134,13 @@ final class DeleteTest extends \QueryStringTest
             ->strictMode(false);
 
         $this->assertEquals(
-            'DELETE FROM `test` WHERE ( (`test`.column_1 = :column_1) OR (`test`.column_2 = :column_2) )',
+            'DELETE FROM test WHERE ( (test.column_1 = :column_1) OR (test.column_2 = :column_2) )',
             $delete->__toString(),
             'update statment must have using or statment'
         );
 
         $this->assertEquals(
-            "DELETE FROM `test` WHERE ( (`test`.column_1 = 123) OR (`test`.column_2 = 'abc') )",
+            "DELETE FROM test WHERE ( (test.column_1 = 123) OR (test.column_2 = 'abc') )",
             $delete->queryBind(),
             'update statment must have using or statment'
         );

--- a/tests/DataBase/Query/InsertTest.php
+++ b/tests/DataBase/Query/InsertTest.php
@@ -17,12 +17,12 @@ final class InsertTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'INSERT INTO `test` (a) VALUES (:bind_a)',
+            'INSERT INTO test (a) VALUES (:bind_a)',
             $insert->__toString()
         );
 
         $this->assertEquals(
-            'INSERT INTO `test` (a) VALUES (1)',
+            'INSERT INTO test (a) VALUES (1)',
             $insert->queryBind()
         );
     }
@@ -40,12 +40,12 @@ final class InsertTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'INSERT INTO `test` (a, c, e) VALUES (:bind_a, :bind_c, :bind_e)',
+            'INSERT INTO test (a, c, e) VALUES (:bind_a, :bind_c, :bind_e)',
             $insert->__toString()
         );
 
         $this->assertEquals(
-            "INSERT INTO `test` (a, c, e) VALUES ('b', 'd', 'f')",
+            "INSERT INTO test (a, c, e) VALUES ('b', 'd', 'f')",
             $insert->queryBind()
         );
     }
@@ -64,12 +64,12 @@ final class InsertTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'INSERT INTO `test` (a, c, e, g) VALUES (:bind_a, :bind_c, :bind_e, :bind_g)',
+            'INSERT INTO test (a, c, e, g) VALUES (:bind_a, :bind_c, :bind_e, :bind_g)',
             $insert->__toString()
         );
 
         $this->assertEquals(
-            "INSERT INTO `test` (a, c, e, g) VALUES ('b', 'd', 'f', 'h')",
+            "INSERT INTO test (a, c, e, g) VALUES ('b', 'd', 'f', 'h')",
             $insert->queryBind()
         );
     }
@@ -92,12 +92,12 @@ final class InsertTest extends \QueryStringTest
             ]);
 
         $this->assertEquals(
-            'INSERT INTO `test` (a, c, e) VALUES (:bind_0_a, :bind_0_c, :bind_0_e), (:bind_1_a, :bind_1_c, :bind_1_e)',
+            'INSERT INTO test (a, c, e) VALUES (:bind_0_a, :bind_0_c, :bind_0_e), (:bind_1_a, :bind_1_c, :bind_1_e)',
             $insert->__toString()
         );
 
         $this->assertEquals(
-            "INSERT INTO `test` (a, c, e) VALUES ('b', 'd', 'f'), ('b', 'd', 'f')",
+            "INSERT INTO test (a, c, e) VALUES ('b', 'd', 'f'), ('b', 'd', 'f')",
             $insert->queryBind()
         );
     }

--- a/tests/DataBase/Query/JoinTest.php
+++ b/tests/DataBase/Query/JoinTest.php
@@ -24,12 +24,12 @@ final class JoinTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` INNER JOIN join_table ON `base_table`.base_id = join_table.join_id',
+            'SELECT * FROM base_table INNER JOIN join_table ON base_table.base_id = join_table.join_id',
             $join->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` INNER JOIN join_table ON `base_table`.base_id = join_table.join_id',
+            'SELECT * FROM base_table INNER JOIN join_table ON base_table.base_id = join_table.join_id',
             $join->queryBind()
         );
     }
@@ -43,12 +43,12 @@ final class JoinTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` LEFT JOIN join_table ON `base_table`.base_id = join_table.join_id',
+            'SELECT * FROM base_table LEFT JOIN join_table ON base_table.base_id = join_table.join_id',
             $join->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` LEFT JOIN join_table ON `base_table`.base_id = join_table.join_id',
+            'SELECT * FROM base_table LEFT JOIN join_table ON base_table.base_id = join_table.join_id',
             $join->queryBind()
         );
     }
@@ -62,12 +62,12 @@ final class JoinTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` RIGHT JOIN join_table ON `base_table`.base_id = join_table.join_id',
+            'SELECT * FROM base_table RIGHT JOIN join_table ON base_table.base_id = join_table.join_id',
             $join->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` RIGHT JOIN join_table ON `base_table`.base_id = join_table.join_id',
+            'SELECT * FROM base_table RIGHT JOIN join_table ON base_table.base_id = join_table.join_id',
             $join->queryBind()
         );
     }
@@ -81,12 +81,12 @@ final class JoinTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` FULL OUTER JOIN join_table ON `base_table`.base_id = join_table.join_id',
+            'SELECT * FROM base_table FULL OUTER JOIN join_table ON base_table.base_id = join_table.join_id',
             $join->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` FULL OUTER JOIN join_table ON `base_table`.base_id = join_table.join_id',
+            'SELECT * FROM base_table FULL OUTER JOIN join_table ON base_table.base_id = join_table.join_id',
             $join->queryBind()
         );
     }
@@ -100,12 +100,12 @@ final class JoinTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` CROSS JOIN join_table',
+            'SELECT * FROM base_table CROSS JOIN join_table',
             $join->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` CROSS JOIN join_table',
+            'SELECT * FROM base_table CROSS JOIN join_table',
             $join->queryBind()
         );
     }
@@ -120,12 +120,12 @@ final class JoinTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` INNER JOIN join_table_1 ON `base_table`.base_id = join_table_1.join_id INNER JOIN join_table_2 ON `base_table`.base_id = join_table_2.join_id',
+            'SELECT * FROM base_table INNER JOIN join_table_1 ON base_table.base_id = join_table_1.join_id INNER JOIN join_table_2 ON base_table.base_id = join_table_2.join_id',
             $join->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` INNER JOIN join_table_1 ON `base_table`.base_id = join_table_1.join_id INNER JOIN join_table_2 ON `base_table`.base_id = join_table_2.join_id',
+            'SELECT * FROM base_table INNER JOIN join_table_1 ON base_table.base_id = join_table_1.join_id INNER JOIN join_table_2 ON base_table.base_id = join_table_2.join_id',
             $join->queryBind()
         );
     }
@@ -140,12 +140,12 @@ final class JoinTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` INNER JOIN join_table_1 ON `base_table`.base_id = join_table_1.join_id WHERE ( (`base_table`.a = :a) )',
+            'SELECT * FROM base_table INNER JOIN join_table_1 ON base_table.base_id = join_table_1.join_id WHERE ( (base_table.a = :a) )',
             $join->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` INNER JOIN join_table_1 ON `base_table`.base_id = join_table_1.join_id WHERE ( (`base_table`.a = 1) )',
+            'SELECT * FROM base_table INNER JOIN join_table_1 ON base_table.base_id = join_table_1.join_id WHERE ( (base_table.a = 1) )',
             $join->queryBind()
         );
     }
@@ -167,12 +167,12 @@ final class JoinTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` INNER JOIN (SELECT join_id FROM `join_table` WHERE (`join_table`.`join_id` IN (:in_0, :in_1))) AS `join_table` ON `base_table`.base_id = `join_table`.join_id ORDER BY `base_table`.`base_id` ASC',
+            'SELECT * FROM base_table INNER JOIN (SELECT join_id FROM join_table WHERE (join_table.join_id IN (:in_0, :in_1))) AS join_table ON base_table.base_id = join_table.join_id ORDER BY base_table.base_id ASC',
             $join->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `base_table` INNER JOIN (SELECT join_id FROM `join_table` WHERE (`join_table`.`join_id` IN (1, 2))) AS `join_table` ON `base_table`.base_id = `join_table`.join_id ORDER BY `base_table`.`base_id` ASC',
+            'SELECT * FROM base_table INNER JOIN (SELECT join_id FROM join_table WHERE (join_table.join_id IN (1, 2))) AS join_table ON base_table.base_id = join_table.join_id ORDER BY base_table.base_id ASC',
             $join->queryBind()
         );
     }

--- a/tests/DataBase/Query/LimitTest.php
+++ b/tests/DataBase/Query/LimitTest.php
@@ -18,13 +18,13 @@ final class LimitTest extends \QueryStringTest
             ->order('column_1', MyQuery::ORDER_ASC);
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end) ORDER BY `test`.`column_1` ASC LIMIT 1, 10',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN :b_start AND :b_end) ORDER BY test.column_1 ASC LIMIT 1, 10',
             $select->__toString(),
             'select with where statment is between'
         );
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN 1 AND 100) ORDER BY `test`.`column_1` ASC LIMIT 1, 10',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN 1 AND 100) ORDER BY test.column_1 ASC LIMIT 1, 10',
             $select->queryBind(),
             'select with where statment is between'
         );
@@ -40,13 +40,13 @@ final class LimitTest extends \QueryStringTest
             ->order('column_1', MyQuery::ORDER_ASC);
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end) ORDER BY `test`.`column_1` ASC LIMIT 2, 0',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN :b_start AND :b_end) ORDER BY test.column_1 ASC LIMIT 2, 0',
             $select->__toString(),
             'select with where statment is between'
         );
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN 1 AND 100) ORDER BY `test`.`column_1` ASC LIMIT 2, 0',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN 1 AND 100) ORDER BY test.column_1 ASC LIMIT 2, 0',
             $select->queryBind(),
             'select with where statment is between'
         );
@@ -62,12 +62,12 @@ final class LimitTest extends \QueryStringTest
             ->order('column_1', MyQuery::ORDER_ASC);
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end) ORDER BY `test`.`column_1` ASC LIMIT 2',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN :b_start AND :b_end) ORDER BY test.column_1 ASC LIMIT 2',
             $select->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN 1 AND 100) ORDER BY `test`.`column_1` ASC LIMIT 2',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN 1 AND 100) ORDER BY test.column_1 ASC LIMIT 2',
             $select->queryBind()
         );
     }
@@ -83,12 +83,12 @@ final class LimitTest extends \QueryStringTest
             ->order('column_1', MyQuery::ORDER_ASC);
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end) ORDER BY `test`.`column_1` ASC LIMIT 1 OFFSET 10',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN :b_start AND :b_end) ORDER BY test.column_1 ASC LIMIT 1 OFFSET 10',
             $select->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN 1 AND 100) ORDER BY `test`.`column_1` ASC LIMIT 1 OFFSET 10',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN 1 AND 100) ORDER BY test.column_1 ASC LIMIT 1 OFFSET 10',
             $select->queryBind()
         );
     }
@@ -103,11 +103,11 @@ final class LimitTest extends \QueryStringTest
             ->order('column_1', MyQuery::ORDER_ASC);
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end) ORDER BY `test`.`column_1` ASC',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN :b_start AND :b_end) ORDER BY test.column_1 ASC',
             $select->__toString()
         );
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end) ORDER BY `test`.`column_1` ASC',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN :b_start AND :b_end) ORDER BY test.column_1 ASC',
             $select->__toString()
         );
     }

--- a/tests/DataBase/Query/Schema/Table/AlterTest.php
+++ b/tests/DataBase/Query/Schema/Table/AlterTest.php
@@ -16,7 +16,7 @@ final class AlterTest extends \QueryStringTest
         $schema('update_add')->int(17);
 
         $this->assertEquals(
-            'ALTER TABLE testing_db.test MODIFY COLUMN `create_add` int(17), MODIFY COLUMN `update_add` int(17);',
+            'ALTER TABLE testing_db.test MODIFY COLUMN create_add int(17), MODIFY COLUMN update_add int(17);',
             $schema->__toString()
         );
     }
@@ -29,7 +29,7 @@ final class AlterTest extends \QueryStringTest
         $schema->add('LastName')->varchar(255);
 
         $this->assertEquals(
-            'ALTER TABLE testing_db.test ADD `PersonID` int, ADD `LastName` varchar(255);',
+            'ALTER TABLE testing_db.test ADD PersonID int, ADD LastName varchar(255);',
             $schema->__toString()
         );
     }
@@ -42,7 +42,7 @@ final class AlterTest extends \QueryStringTest
         $schema->drop('LastName');
 
         $this->assertEquals(
-            'ALTER TABLE testing_db.test DROP COLUMN `PersonID`, DROP COLUMN `LastName`;',
+            'ALTER TABLE testing_db.test DROP COLUMN PersonID, DROP COLUMN LastName;',
             $schema->__toString()
         );
     }
@@ -54,7 +54,7 @@ final class AlterTest extends \QueryStringTest
         $schema->rename('PersonID', 'person_id');
 
         $this->assertEquals(
-            'ALTER TABLE testing_db.test RENAME COLUMN `PersonID` TO `person_id`;',
+            'ALTER TABLE testing_db.test RENAME COLUMN PersonID TO person_id;',
             $schema->__toString()
         );
     }
@@ -67,7 +67,7 @@ final class AlterTest extends \QueryStringTest
         $schema->rename('PersonID', 'person_id');
 
         $this->assertEquals(
-            'ALTER TABLE testing_db.test RENAME COLUMN `PersonID` TO `person_id`;',
+            'ALTER TABLE testing_db.test RENAME COLUMN PersonID TO person_id;',
             $schema->__toString(),
             'multy rename column will use last rename'
         );
@@ -82,7 +82,7 @@ final class AlterTest extends \QueryStringTest
         $schema->column('create_add')->int(17);
 
         $this->assertEquals(
-            'ALTER TABLE testing_db.test MODIFY COLUMN `create_add` int(17), ADD `PersonID` int(4), DROP COLUMN `LastName`;',
+            'ALTER TABLE testing_db.test MODIFY COLUMN create_add int(17), ADD PersonID int(4), DROP COLUMN LastName;',
             $schema->__toString()
         );
     }
@@ -95,7 +95,7 @@ final class AlterTest extends \QueryStringTest
         $schema->column('create_add')->after('id');
 
         $this->assertEquals(
-            'ALTER TABLE testing_db.test MODIFY COLUMN `uuid` int(17) FIRST, MODIFY COLUMN `create_add` AFTER `id`;',
+            'ALTER TABLE testing_db.test MODIFY COLUMN uuid int(17) FIRST, MODIFY COLUMN create_add AFTER id;',
             $schema->__toString()
         );
     }
@@ -108,7 +108,7 @@ final class AlterTest extends \QueryStringTest
         $schema->add('create_add')->int(17)->after('id');
 
         $this->assertEquals(
-            'ALTER TABLE testing_db.test ADD `uuid` int(17) FIRST, ADD `create_add` int(17) AFTER `id`;',
+            'ALTER TABLE testing_db.test ADD uuid int(17) FIRST, ADD create_add int(17) AFTER id;',
             $schema->__toString()
         );
     }

--- a/tests/DataBase/Query/Schema/Table/CreateTest.php
+++ b/tests/DataBase/Query/Schema/Table/CreateTest.php
@@ -18,7 +18,7 @@ final class CreateTest extends \QueryStringTest
         $schema->primaryKey('PersonID');
 
         $this->assertEquals(
-            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (`PersonID`) )',
+            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (PersonID) )',
             $schema->__toString()
         );
     }
@@ -33,7 +33,7 @@ final class CreateTest extends \QueryStringTest
         $schema->primaryKey('LastName');
 
         $this->assertEquals(
-            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (`PersonID`, `LastName`) )',
+            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (PersonID, LastName) )',
             $schema->__toString()
         );
     }
@@ -60,7 +60,7 @@ final class CreateTest extends \QueryStringTest
         $schema->unique('PersonID');
 
         $this->assertEquals(
-            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), UNIQUE (`PersonID`) )',
+            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), UNIQUE (PersonID) )',
             $schema->__toString()
         );
     }
@@ -75,7 +75,7 @@ final class CreateTest extends \QueryStringTest
         $schema->unique('LastName');
 
         $this->assertEquals(
-            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), UNIQUE (`PersonID`, `LastName`) )',
+            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), UNIQUE (PersonID, LastName) )',
             $schema->__toString()
         );
     }
@@ -91,7 +91,7 @@ final class CreateTest extends \QueryStringTest
         $schema->primaryKey('PersonID');
 
         $this->assertEquals(
-            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (`PersonID`) )',
+            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (PersonID) )',
             $schema->__toString()
         );
     }
@@ -105,7 +105,7 @@ final class CreateTest extends \QueryStringTest
         $schema->primaryKey('PersonID');
 
         $this->assertEquals(
-            'CREATE TABLE testing_db.test ( `PersonID` int, `LastName` varchar(255), PRIMARY KEY (`PersonID`) )',
+            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (PersonID) )',
             $schema->__toString()
         );
     }
@@ -120,7 +120,7 @@ final class CreateTest extends \QueryStringTest
         $schema->primaryKey('PersonID');
 
         $this->assertEquals(
-            "CREATE TABLE testing_db.test ( `PersonID` int UNSIGNED DEFAULT 1, `LastName` varchar(255) DEFAULT '-', `sufix` varchar(15) DEFAULT NULL, PRIMARY KEY (`PersonID`) )",
+            "CREATE TABLE testing_db.test ( PersonID int UNSIGNED DEFAULT 1, LastName varchar(255) DEFAULT '-', sufix varchar(15) DEFAULT NULL, PRIMARY KEY (PersonID) )",
             $schema->__toString()
         );
     }
@@ -134,7 +134,7 @@ final class CreateTest extends \QueryStringTest
         $schema->primaryKey('PersonID');
 
         $this->assertEquals(
-            'CREATE TABLE testing_db.test ( `PersonID` int NOT NULL, `LastName` varchar(255) NULL, PRIMARY KEY (`PersonID`) )',
+            'CREATE TABLE testing_db.test ( PersonID int NOT NULL, LastName varchar(255) NULL, PRIMARY KEY (PersonID) )',
             $schema->__toString()
         );
     }
@@ -149,7 +149,7 @@ final class CreateTest extends \QueryStringTest
         $schema->engine(Create::INNODB);
 
         $this->assertEquals(
-            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (`PersonID`) ) ENGINE=INNODB',
+            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (PersonID) ) ENGINE=INNODB',
             $schema->__toString()
         );
     }
@@ -164,7 +164,7 @@ final class CreateTest extends \QueryStringTest
         $schema->character('utf8mb4');
 
         $this->assertEquals(
-            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (`PersonID`) ) CHARACTER SET utf8mb4',
+            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (PersonID) ) CHARACTER SET utf8mb4',
             $schema->__toString()
         );
     }
@@ -180,7 +180,7 @@ final class CreateTest extends \QueryStringTest
         $schema->character('utf8mb4');
 
         $this->assertEquals(
-            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (`PersonID`) ) ENGINE=INNODB CHARACTER SET utf8mb4',
+            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (PersonID) ) ENGINE=INNODB CHARACTER SET utf8mb4',
             $schema->__toString()
         );
     }

--- a/tests/DataBase/Query/Schema/Table/DataTypesTest.php
+++ b/tests/DataBase/Query/Schema/Table/DataTypesTest.php
@@ -16,7 +16,7 @@ final class DataTypesTest extends \QueryStringTest
         $schema('size')->enum(['x-small', 'small', 'medium', 'large', 'x-large']);
 
         $this->assertEquals(
-            "CREATE TABLE testing_db.test ( `name` varchar(40), `size` ENUM ('x-small', 'small', 'medium', 'large', 'x-large') )",
+            "CREATE TABLE testing_db.test ( name varchar(40), size ENUM ('x-small', 'small', 'medium', 'large', 'x-large') )",
             $schema->__toString()
         );
     }

--- a/tests/DataBase/Query/Schema/Table/RawTest.php
+++ b/tests/DataBase/Query/Schema/Table/RawTest.php
@@ -11,10 +11,10 @@ final class RawTest extends \QueryStringTest
     /** @test */
     public function itCanGenerateQueryUsingAddColumn()
     {
-        $schema = new Raw('CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (`PersonID`) )', $this->pdo_schame);
+        $schema = new Raw('CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (PersonID) )', $this->pdo_schame);
 
         $this->assertEquals(
-            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (`PersonID`) )',
+            'CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (PersonID) )',
             $schema->__toString()
         );
     }

--- a/tests/DataBase/Query/SelectTest.php
+++ b/tests/DataBase/Query/SelectTest.php
@@ -19,12 +19,12 @@ final class SelectTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end)',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN :b_start AND :b_end)',
             $select->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` BETWEEN 1 AND 100)',
+            'SELECT * FROM test WHERE (test.column_1 BETWEEN 1 AND 100)',
             $select->queryBind()
         );
     }
@@ -38,12 +38,12 @@ final class SelectTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE ( (`test`.column_1 = :column_1) )',
+            'SELECT * FROM test WHERE ( (test.column_1 = :column_1) )',
             $select->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE ( (`test`.column_1 = 100) )',
+            'SELECT * FROM test WHERE ( (test.column_1 = 100) )',
             $select->queryBind()
         );
     }
@@ -57,12 +57,12 @@ final class SelectTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE ( (`test`.column_1 = :column_1) )',
+            'SELECT * FROM test WHERE ( (test.column_1 = :column_1) )',
             $select->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE ( (`test`.column_1 = 100) )',
+            'SELECT * FROM test WHERE ( (test.column_1 = 100) )',
             $select->queryBind()
         );
     }
@@ -76,12 +76,12 @@ final class SelectTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` IN (:in_0, :in_1))',
+            'SELECT * FROM test WHERE (test.column_1 IN (:in_0, :in_1))',
             $select->__toString()
         );
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE (`test`.`column_1` IN (1, 2))',
+            'SELECT * FROM test WHERE (test.column_1 IN (1, 2))',
             $select->queryBind()
         );
     }
@@ -95,12 +95,12 @@ final class SelectTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE ( (`test`.column_1 LIKE :column_1) )',
+            'SELECT * FROM test WHERE ( (test.column_1 LIKE :column_1) )',
             $select->__toString()
         );
 
         $this->assertEquals(
-            "SELECT * FROM `test` WHERE ( (`test`.column_1 LIKE 'test') )",
+            "SELECT * FROM test WHERE ( (test.column_1 LIKE 'test') )",
             $select->queryBind()
         );
     }
@@ -114,13 +114,13 @@ final class SelectTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE a < :a OR b > :b',
+            'SELECT * FROM test WHERE a < :a OR b > :b',
             $select->__toString(),
             'select with where statment is like'
         );
 
         $this->assertEquals(
-            'SELECT * FROM `test` WHERE a < 1 OR b > 2',
+            'SELECT * FROM test WHERE a < 1 OR b > 2',
             $select->queryBind(),
             'select with where statment is like'
         );
@@ -136,13 +136,13 @@ final class SelectTest extends \QueryStringTest
             ->equal('column_3', true);
 
         $this->assertEquals(
-            'SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (`test`.column_1 = :column_1) AND (`test`.column_2 = :column_2) AND (`test`.column_3 = :column_3) )',
+            'SELECT column_1, column_2, column_3 FROM test WHERE ( (test.column_1 = :column_1) AND (test.column_2 = :column_2) AND (test.column_3 = :column_3) )',
             $select->__toString(),
             'select statment must have 3 selected query'
         );
 
         $this->assertEquals(
-            "SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (`test`.column_1 = 123) AND (`test`.column_2 = 'abc') AND (`test`.column_3 = true) )",
+            "SELECT column_1, column_2, column_3 FROM test WHERE ( (test.column_1 = 123) AND (test.column_2 = 'abc') AND (test.column_3 = true) )",
             $select->queryBind(),
             'select statment must have 3 selected query'
         );
@@ -158,13 +158,13 @@ final class SelectTest extends \QueryStringTest
             ->strictMode(false);
 
         $this->assertEquals(
-            'SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (`test`.column_1 = :column_1) OR (`test`.column_2 = :column_2) )',
+            'SELECT column_1, column_2, column_3 FROM test WHERE ( (test.column_1 = :column_1) OR (test.column_2 = :column_2) )',
             $select,
             'select statment must have using or statment'
         );
 
         $this->assertEquals(
-            "SELECT `column_1`, `column_2`, `column_3` FROM `test` WHERE ( (`test`.column_1 = 123) OR (`test`.column_2 = 'abc') )",
+            "SELECT column_1, column_2, column_3 FROM test WHERE ( (test.column_1 = 123) OR (test.column_2 = 'abc') )",
             $select->queryBind(),
             'select statment must have using or statment'
         );
@@ -185,13 +185,13 @@ final class SelectTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `base_1` WHERE EXISTS ( SELECT * FROM `base_2` WHERE ( (`base_2`.test = :test) ) AND base_1.id = base_2.id ) ORDER BY `base_1`.`id` ASC LIMIT 1, 10',
+            'SELECT * FROM base_1 WHERE EXISTS ( SELECT * FROM base_2 WHERE ( (base_2.test = :test) ) AND base_1.id = base_2.id ) ORDER BY base_1.id ASC LIMIT 1, 10',
             $select->__toString(),
             'where exist query'
         );
 
         $this->assertEquals(
-            "SELECT * FROM `base_1` WHERE EXISTS ( SELECT * FROM `base_2` WHERE ( (`base_2`.test = 'success') ) AND base_1.id = base_2.id ) ORDER BY `base_1`.`id` ASC LIMIT 1, 10",
+            "SELECT * FROM base_1 WHERE EXISTS ( SELECT * FROM base_2 WHERE ( (base_2.test = 'success') ) AND base_1.id = base_2.id ) ORDER BY base_1.id ASC LIMIT 1, 10",
             $select->queryBind(),
             'where exist query'
         );
@@ -212,13 +212,13 @@ final class SelectTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `base_1` WHERE NOT EXISTS ( SELECT * FROM `base_2` WHERE ( (`base_2`.test = :test) ) AND base_1.id = base_2.id ) ORDER BY `base_1`.`id` ASC LIMIT 1, 10',
+            'SELECT * FROM base_1 WHERE NOT EXISTS ( SELECT * FROM base_2 WHERE ( (base_2.test = :test) ) AND base_1.id = base_2.id ) ORDER BY base_1.id ASC LIMIT 1, 10',
             $select->__toString(),
             'where exist query'
         );
 
         $this->assertEquals(
-            "SELECT * FROM `base_1` WHERE NOT EXISTS ( SELECT * FROM `base_2` WHERE ( (`base_2`.test = 'success') ) AND base_1.id = base_2.id ) ORDER BY `base_1`.`id` ASC LIMIT 1, 10",
+            "SELECT * FROM base_1 WHERE NOT EXISTS ( SELECT * FROM base_2 WHERE ( (base_2.test = 'success') ) AND base_1.id = base_2.id ) ORDER BY base_1.id ASC LIMIT 1, 10",
             $select->queryBind(),
             'where exist query'
         );
@@ -230,7 +230,7 @@ final class SelectTest extends \QueryStringTest
         $select = MyQuery::from('base_1', $this->PDO)
             ->select()
             ->whereClause(
-                '`user` =',
+                'user =',
                 (new Select('base_2', ['*'], $this->PDO))
                     ->equal('test', 'success')
                     ->where('base_1.id = base_2.id')
@@ -240,13 +240,13 @@ final class SelectTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT * FROM `base_1` WHERE `user` = ( SELECT * FROM `base_2` WHERE ( (`base_2`.test = :test) ) AND base_1.id = base_2.id ) ORDER BY `base_1`.`id` ASC LIMIT 1, 10',
+            'SELECT * FROM base_1 WHERE user = ( SELECT * FROM base_2 WHERE ( (base_2.test = :test) ) AND base_1.id = base_2.id ) ORDER BY base_1.id ASC LIMIT 1, 10',
             $select->__toString(),
             'where exist query'
         );
 
         $this->assertEquals(
-            "SELECT * FROM `base_1` WHERE `user` = ( SELECT * FROM `base_2` WHERE ( (`base_2`.test = 'success') ) AND base_1.id = base_2.id ) ORDER BY `base_1`.`id` ASC LIMIT 1, 10",
+            "SELECT * FROM base_1 WHERE user = ( SELECT * FROM base_2 WHERE ( (base_2.test = 'success') ) AND base_1.id = base_2.id ) ORDER BY base_1.id ASC LIMIT 1, 10",
             $select->queryBind(),
             'where exist query'
         );
@@ -268,13 +268,13 @@ final class SelectTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'SELECT user.id as id FROM (SELECT id FROM `base_2` WHERE (`base_2`.`test` IN (:in_0))) AS `user` ORDER BY `user`.`id` ASC LIMIT 1, 10',
+            'SELECT user.id as id FROM (SELECT id FROM base_2 WHERE (base_2.test IN (:in_0))) AS user ORDER BY user.id ASC LIMIT 1, 10',
             $select->__toString(),
             'where exist query'
         );
 
         $this->assertEquals(
-            "SELECT user.id as id FROM (SELECT id FROM `base_2` WHERE (`base_2`.`test` IN ('success'))) AS `user` ORDER BY `user`.`id` ASC LIMIT 1, 10",
+            "SELECT user.id as id FROM (SELECT id FROM base_2 WHERE (base_2.test IN ('success'))) AS user ORDER BY user.id ASC LIMIT 1, 10",
             $select->queryBind(),
             'where exist query'
         );

--- a/tests/DataBase/Query/UpdateTest.php
+++ b/tests/DataBase/Query/UpdateTest.php
@@ -18,12 +18,12 @@ final class UpdateTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'UPDATE `test` SET `a` = :bind_a WHERE (`test`.`column_1` BETWEEN :b_start AND :b_end)',
+            'UPDATE test SET a = :bind_a WHERE (test.column_1 BETWEEN :b_start AND :b_end)',
             $update->__toString()
         );
 
         $this->assertEquals(
-            "UPDATE `test` SET `a` = 'b' WHERE (`test`.`column_1` BETWEEN 1 AND 100)",
+            "UPDATE test SET a = 'b' WHERE (test.column_1 BETWEEN 1 AND 100)",
             $update->queryBind()
         );
     }
@@ -38,12 +38,12 @@ final class UpdateTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'UPDATE `test` SET `a` = :bind_a WHERE ( (`test`.column_1 = :column_1) )',
+            'UPDATE test SET a = :bind_a WHERE ( (test.column_1 = :column_1) )',
             $update->__toString()
         );
 
         $this->assertEquals(
-            "UPDATE `test` SET `a` = 'b' WHERE ( (`test`.column_1 = 100) )",
+            "UPDATE test SET a = 'b' WHERE ( (test.column_1 = 100) )",
             $update->queryBind()
         );
     }
@@ -58,12 +58,12 @@ final class UpdateTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'UPDATE `test` SET `a` = :bind_a WHERE ( (`test`.column_1 = :column_1) )',
+            'UPDATE test SET a = :bind_a WHERE ( (test.column_1 = :column_1) )',
             $update->__toString()
         );
 
         $this->assertEquals(
-            "UPDATE `test` SET `a` = 'b' WHERE ( (`test`.column_1 = 100) )",
+            "UPDATE test SET a = 'b' WHERE ( (test.column_1 = 100) )",
             $update->queryBind()
         );
     }
@@ -78,12 +78,12 @@ final class UpdateTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'UPDATE `test` SET `a` = :bind_a WHERE (`test`.`column_1` IN (:in_0, :in_1))',
+            'UPDATE test SET a = :bind_a WHERE (test.column_1 IN (:in_0, :in_1))',
             $update->__toString()
         );
 
         $this->assertEquals(
-            "UPDATE `test` SET `a` = 'b' WHERE (`test`.`column_1` IN (1, 2))",
+            "UPDATE test SET a = 'b' WHERE (test.column_1 IN (1, 2))",
             $update->queryBind()
         );
     }
@@ -98,12 +98,12 @@ final class UpdateTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'UPDATE `test` SET `a` = :bind_a WHERE ( (`test`.column_1 LIKE :column_1) )',
+            'UPDATE test SET a = :bind_a WHERE ( (test.column_1 LIKE :column_1) )',
             $update->__toString()
         );
 
         $this->assertEquals(
-            "UPDATE `test` SET `a` = 'b' WHERE ( (`test`.column_1 LIKE 'test') )",
+            "UPDATE test SET a = 'b' WHERE ( (test.column_1 LIKE 'test') )",
             $update->queryBind()
         );
     }
@@ -118,13 +118,13 @@ final class UpdateTest extends \QueryStringTest
         ;
 
         $this->assertEquals(
-            'UPDATE `test` SET `a` = :bind_a WHERE a < :a OR b > :b',
+            'UPDATE test SET a = :bind_a WHERE a < :a OR b > :b',
             $update->__toString(),
             'update with where statment is like'
         );
 
         $this->assertEquals(
-            "UPDATE `test` SET `a` = 'b' WHERE a < 1 OR b > 2",
+            "UPDATE test SET a = 'b' WHERE a < 1 OR b > 2",
             $update->queryBind(),
             'update with where statment is like'
         );
@@ -141,12 +141,12 @@ final class UpdateTest extends \QueryStringTest
             ->strictMode(false);
 
         $this->assertEquals(
-            'UPDATE `test` SET `a` = :bind_a WHERE ( (`test`.column_1 = :column_1) OR (`test`.column_2 = :column_2) )',
+            'UPDATE test SET a = :bind_a WHERE ( (test.column_1 = :column_1) OR (test.column_2 = :column_2) )',
             $update->__toString()
         );
 
         $this->assertEquals(
-            "UPDATE `test` SET `a` = 'b' WHERE ( (`test`.column_1 = 123) OR (`test`.column_2 = 'abc') )",
+            "UPDATE test SET a = 'b' WHERE ( (test.column_1 = 123) OR (test.column_2 = 'abc') )",
             $update->queryBind()
         );
     }

--- a/tests/DataBase/RealDatabase/DeleteTest.php
+++ b/tests/DataBase/RealDatabase/DeleteTest.php
@@ -112,7 +112,7 @@ final class DeleteTest extends \RealDatabaseConnectionTest
     {
         MyQuery::from('users', $this->pdo)
             ->delete()
-            ->where('`user` = :user', [
+            ->where('user = :user', [
                 [':user', 'taylor'],
             ])
             ->execute()
@@ -131,7 +131,7 @@ final class DeleteTest extends \RealDatabaseConnectionTest
         MyQuery::from('users', $this->pdo)
             ->delete()
             ->compare('stat', '>', 1)
-            ->where('`user` = :user', [
+            ->where('user = :user', [
                 [':user', 'taylor'],
             ])
             ->execute()

--- a/tests/DataBase/RealDatabase/Schema/Table/AlterTest.php
+++ b/tests/DataBase/RealDatabase/Schema/Table/AlterTest.php
@@ -13,13 +13,13 @@ final class AlterTest extends \RealDatabaseConnectionTest
         parent::setUp();
 
         $this->pdo
-            ->query('CREATE TABLE `profiles` (
-                `user` varchar(10) NOT NULL,
-                `name` varchar(500) NOT NULL,
-                `stat` int(2) NOT NULL,
-                `create_at` int(12) NOT NULL,
-                `update_at` int(12) NOT NULL,
-                PRIMARY KEY (`user`)
+            ->query('CREATE TABLE profiles (
+                user varchar(10) NOT NULL,
+                name varchar(500) NOT NULL,
+                stat int(2) NOT NULL,
+                create_at int(12) NOT NULL,
+                update_at int(12) NOT NULL,
+                PRIMARY KEY (user)
               )')
             ->execute();
     }

--- a/tests/DataBase/RealDatabase/Schema/Table/RawTest.php
+++ b/tests/DataBase/RealDatabase/Schema/Table/RawTest.php
@@ -15,7 +15,7 @@ final class RawTest extends \RealDatabaseConnectionTest
      */
     public function itCanGenerateCreateDatabase()
     {
-        $schema = new Raw('CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (`PersonID`) )', $this->pdo_schema);
+        $schema = new Raw('CREATE TABLE testing_db.test ( PersonID int, LastName varchar(255), PRIMARY KEY (PersonID) )', $this->pdo_schema);
 
         $this->assertTrue($schema->execute());
     }

--- a/tests/DataBase/RealDatabase/SelectTest.php
+++ b/tests/DataBase/RealDatabase/SelectTest.php
@@ -13,17 +13,17 @@ final class SelectTest extends \RealDatabaseConnectionTest
     {
         // factory
         $this->pdo
-            ->query('CREATE TABLE `profiles` (
-                `user` varchar(32) NOT NULL,
-                `real_name` varchar(500) NOT NULL,
-                PRIMARY KEY (`user`)
+            ->query('CREATE TABLE profiles (
+                user varchar(32) NOT NULL,
+                real_name varchar(500) NOT NULL,
+                PRIMARY KEY (user)
               )')
             ->execute();
 
         $this->pdo
-            ->query('INSERT INTO `profiles` (
-                `user`,
-                `real_name`
+            ->query('INSERT INTO profiles (
+                user,
+                real_name
               ) VALUES (
                 :user,
                 :real_name
@@ -156,7 +156,7 @@ final class SelectTest extends \RealDatabaseConnectionTest
     {
         $users = MyQuery::from('users', $this->pdo)
             ->select()
-            ->where('`user` = :user', [
+            ->where('user = :user', [
                 [':user', 'taylor'],
             ])
             ->all()
@@ -175,7 +175,7 @@ final class SelectTest extends \RealDatabaseConnectionTest
         $users = MyQuery::from('users', $this->pdo)
             ->select()
             ->compare('stat', '>', 1)
-            ->where('`user` = :user', [
+            ->where('user = :user', [
                 [':user', 'taylor'],
             ])
             ->all()

--- a/tests/DataBase/RealDatabase/UpdateTest.php
+++ b/tests/DataBase/RealDatabase/UpdateTest.php
@@ -119,7 +119,7 @@ final class UpdateTest extends \RealDatabaseConnectionTest
         MyQuery::from('users', $this->pdo)
             ->update()
             ->value('stat', 0)
-            ->where('`user` = :user', [
+            ->where('user = :user', [
                 [':user', 'taylor'],
             ])
             ->execute()
@@ -139,7 +139,7 @@ final class UpdateTest extends \RealDatabaseConnectionTest
             ->update()
             ->value('stat', 0)
             ->compare('stat', '>', 1)
-            ->where('`user` = :user', [
+            ->where('user = :user', [
                 [':user', 'taylor'],
             ])
             ->execute()

--- a/tests/DataBase/RealDatabaseConnectionTest.php
+++ b/tests/DataBase/RealDatabaseConnectionTest.php
@@ -36,19 +36,19 @@ abstract class RealDatabaseConnectionTest extends TestCase
 
         // factory
         $this->pdo
-            ->query('CREATE TABLE `users` (
-                `user` varchar(32) NOT NULL,
-                `pwd` varchar(500) NOT NULL,
-                `stat` int(2) NOT NULL,
-                PRIMARY KEY (`user`)
+            ->query('CREATE TABLE users (
+                user varchar(32) NOT NULL,
+                pwd varchar(500) NOT NULL,
+                stat int(2) NOT NULL,
+                PRIMARY KEY (user)
               )')
             ->execute();
 
         $this->pdo
-            ->query('INSERT INTO `users` (
-                `user`,
-                `pwd`,
-                `stat`
+            ->query('INSERT INTO users (
+                user,
+                pwd,
+                stat
               ) VALUES (
                 :user,
                 :pwd,


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **Yes**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues | comma-separated list of tickets # fixed by the PR, if any |

------
Remove backtick in query builder. sometimes column wrap with backtick, we recommended add manually to prevent alias wrap not perfectly.

address of #404