### PR TITLE
feat: add defer function for deferred execution

### DIFF
--- a/src/System/Integrate/helper.php
+++ b/src/System/Integrate/helper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 // path aplication
 
 use System\Http\RedirectResponse;
+use System\Integrate\Application;
 use System\Integrate\Exceptions\ApplicationNotAvailable;
 use System\Router\Router;
 
@@ -299,9 +300,9 @@ if (!function_exists('app')) {
     /**
      * Get Application container.
      */
-    function app(): System\Integrate\Application
+    function app(): Application
     {
-        $app = System\Integrate\Application::getIntance();
+        $app = Application::getIntance();
         if (null === $app) {
             throw new ApplicationNotAvailable();
         }
@@ -413,5 +414,24 @@ if (!function_exists('abort')) {
     function abort(int $code, string $message = '', array $headers = []): void
     {
         app()->abort($code, $message, $headers);
+    }
+}
+
+if (false === function_exists('defer')) {
+    /**
+     * Terminate application after response send.
+     */
+    function defer(callable $callback): bool
+    {
+        if (function_exists('fastcgi_finish_request')
+        || function_exists('litespeed_finish_request')
+        || false === in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)
+        ) {
+            Application::getIntance()->registerTerminate($callback);
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Integrate/ApplicationTest.php
+++ b/tests/Integrate/ApplicationTest.php
@@ -256,6 +256,25 @@ class ApplicationTest extends TestCase
     }
 
     /** @test */
+    public function itCanDeferFunctionExecution()
+    {
+        $app  = new Application('/');
+        $skip = defer(function () {
+            echo 'deferred.';
+        });
+
+        if (false === $skip) {
+            $this->markTestSkipped('skiped if not support defer.');
+        }
+
+        ob_start();
+        $app->terminate();
+        $out = ob_get_clean();
+
+        $this->assertEquals('deferred.', $out);
+    }
+
+    /** @test */
     public function itCanCallDeprecatedMethod()
     {
         $app = new Application(__DIR__);


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **Yes / No**                                              |
| New feature? | **Yes / No**                                              |
| Breaks BC?   | **Yes / No**                                              |
| Fixed issues | comma-separated list of tickets # fixed by the PR, if any |

------
Introduce a `defer` function to allow deferred execution of callbacks after the response is sent. Include tests to verify the functionality of the new feature.