### PR TITLE
feat: Json Response

### DIFF
--- a/src/System/Http/JsonResponse.php
+++ b/src/System/Http/JsonResponse.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace System\Http;
+
+class JsonResponse extends Response
+{
+    protected int $encoding_option = 15;
+
+    /**
+     * @param array<mixed, mixed>|null $data
+     * @param array<string, string>    $headers Header tosend to client
+     */
+    public function __construct(?array $data = null, int $status_code = 200, array $headers = [])
+    {
+        parent::__construct('', $status_code, $headers);
+        $data ??= [];
+        $this->setData($data);
+    }
+
+    public function setEncodingOption(int $encoding_option): self
+    {
+        $this->encoding_option = $encoding_option;
+
+        return $this;
+    }
+
+    public function setJson(string $json): self
+    {
+        $this->content = $json;
+        $this->prepare();
+
+        return $this;
+    }
+
+    /**
+     * @param array<mixed, mixed> $data
+     */
+    public function setData(array $data): self
+    {
+        $this->content = json_encode($data, $this->encoding_option);
+        $this->prepare();
+
+        return $this;
+    }
+
+    /**
+     * @return array<mixed, mixed>
+     */
+    public function getData(): array
+    {
+        return json_decode($this->content, true);
+    }
+
+    protected function prepare(): void
+    {
+        $this->content_type = 'application/json';
+    }
+}

--- a/src/System/Http/JsonResponse.php
+++ b/src/System/Http/JsonResponse.php
@@ -20,7 +20,7 @@ class JsonResponse extends Response
     public function __construct(?array $data = null, int $status_code = 200, array $headers = [])
     {
         parent::__construct('', $status_code, $headers);
-        $data ??= [];
+        $data ??= new \ArrayObject();
         $this->setData($data);
     }
 
@@ -46,11 +46,14 @@ class JsonResponse extends Response
     }
 
     /**
-     * @param array<mixed, mixed> $data
+     * @throws \Exception throw error when json encode is false
      */
-    public function setData(array $data): self
+    public function setData(mixed $data): self
     {
-        $this->data = json_encode($data, $this->encoding_options);
+        if (false === ($json = json_encode($data, $this->encoding_options))) {
+            throw new \InvalidArgumentException('Invalid encode data.');
+        }
+        $this->data = $json;
         $this->prepare();
 
         return $this;

--- a/src/System/Http/JsonResponse.php
+++ b/src/System/Http/JsonResponse.php
@@ -6,7 +6,12 @@ namespace System\Http;
 
 class JsonResponse extends Response
 {
-    protected int $encoding_option = 15;
+    protected string $data;
+
+    /**
+     * @see https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpFoundation/JsonResponse.php
+     */
+    protected int $encoding_options = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
 
     /**
      * @param array<mixed, mixed>|null $data
@@ -19,16 +24,22 @@ class JsonResponse extends Response
         $this->setData($data);
     }
 
-    public function setEncodingOption(int $encoding_option): self
+    public function setEncodingOptions(int $encoding_options): self
     {
-        $this->encoding_option = $encoding_option;
+        $this->encoding_options = $encoding_options;
+        $this->setData(json_decode($this->data));
 
         return $this;
     }
 
+    public function getEncodingOptions(): int
+    {
+        return $this->encoding_options;
+    }
+
     public function setJson(string $json): self
     {
-        $this->content = $json;
+        $this->data = $json;
         $this->prepare();
 
         return $this;
@@ -39,7 +50,7 @@ class JsonResponse extends Response
      */
     public function setData(array $data): self
     {
-        $this->content = json_encode($data, $this->encoding_option);
+        $this->data = json_encode($data, $this->encoding_options);
         $this->prepare();
 
         return $this;
@@ -50,11 +61,12 @@ class JsonResponse extends Response
      */
     public function getData(): array
     {
-        return json_decode($this->content, true);
+        return json_decode($this->data, true);
     }
 
     protected function prepare(): void
     {
-        $this->content_type = 'application/json';
+        $this->setContentType('application/json');
+        $this->setContent($this->data);
     }
 }

--- a/src/System/Http/Response.php
+++ b/src/System/Http/Response.php
@@ -45,14 +45,12 @@ class Response
      *
      * @var string|array<mixed, mixed>
      */
-    private $content;
+    protected string|array $content;
 
     /**
      * http respone code.
-     *
-     * @var int
      */
-    private $respone_code;
+    protected int $respone_code;
 
     /**
      * Header array pools.
@@ -64,19 +62,22 @@ class Response
      *
      * @var array<int, string>
      */
-    private $remove_headers = [];
+    protected array $remove_headers = [];
 
     /**
      * Content type.
-     *
-     * @var string
-     * */
-    private $content_type = 'text/html';
+     */
+    protected string $content_type = 'text/html';
+
+    /**
+     * Set encoding option for encode json data.
+     */
+    protected int $encoding_option = JSON_NUMERIC_CHECK;
 
     /**
      * Http Protocol version (1.0 or 1.1).
      */
-    private string $protocol_version;
+    protected string $protocol_version;
 
     /**
      * Create rosone http base on conten and header.
@@ -106,7 +107,7 @@ class Response
 
         $header_lines = (string) $this->headers;
         $content      = is_array($this->content)
-            ? json_encode($this->content, JSON_NUMERIC_CHECK)
+            ? json_encode($this->content, $this->encoding_option)
             : $this->content;
 
         return
@@ -159,7 +160,7 @@ class Response
     protected function sendContent()
     {
         echo is_array($this->content)
-            ? json_encode($this->content, JSON_NUMERIC_CHECK)
+            ? json_encode($this->content, $this->encoding_option)
             : $this->content;
     }
 
@@ -225,6 +226,8 @@ class Response
      * @param string|array<mixed, mixed> $content Content to send data
      *
      * @return self
+     *
+     * @deprecated use `JsonRespone::class` instead
      */
     public function json($content = null)
     {

--- a/src/System/Http/Response.php
+++ b/src/System/Http/Response.php
@@ -227,8 +227,6 @@ class Response
      * @param string|array<mixed, mixed> $content Content to send data
      *
      * @return self
-     *
-     * @deprecated use `JsonRespone::class` instead
      */
     public function json($content = null)
     {

--- a/src/System/Http/Response.php
+++ b/src/System/Http/Response.php
@@ -142,7 +142,7 @@ class Response
         }
 
         // remove header
-        if ($this->remove_headers === null) {
+        if ([] === $this->remove_headers) {
             header_remove();
         } else {
             foreach ($this->remove_headers as $header) {

--- a/src/System/Http/Response.php
+++ b/src/System/Http/Response.php
@@ -40,17 +40,18 @@ class Response
     ];
 
     // property
+
     /**
      * Http body content.
      *
      * @var string|array<mixed, mixed>
      */
-    protected string|array $content;
+    private string|array $content;
 
     /**
-     * http respone code.
+     * Http respone code.
      */
-    protected int $respone_code;
+    private int $respone_code;
 
     /**
      * Header array pools.
@@ -62,22 +63,22 @@ class Response
      *
      * @var array<int, string>
      */
-    protected array $remove_headers = [];
+    private array $remove_headers = [];
 
     /**
      * Content type.
      */
-    protected string $content_type = 'text/html';
+    private string $content_type = 'text/html';
+
+    /**
+     * Http Protocol version (1.0 or 1.1).
+     */
+    private string $protocol_version;
 
     /**
      * Set encoding option for encode json data.
      */
     protected int $encoding_option = JSON_NUMERIC_CHECK;
-
-    /**
-     * Http Protocol version (1.0 or 1.1).
-     */
-    protected string $protocol_version;
 
     /**
      * Create rosone http base on conten and header.
@@ -376,6 +377,16 @@ class Response
     }
 
     /**
+     * Set content type.
+     */
+    public function setContentType(string $content_type): self
+    {
+        $this->content_type = $content_type;
+
+        return $this;
+    }
+
+    /**
      * Remove header from origin header.
      *
      * @deprecated use headers property instead
@@ -445,6 +456,14 @@ class Response
     public function getProtocolVersion(): string
     {
         return $this->protocol_version;
+    }
+
+    /**
+     * Get Content http response content type.
+     */
+    public function getContentType(): string
+    {
+        return $this->content_type;
     }
 
     /**

--- a/tests/Http/JsonResponseTest.php
+++ b/tests/Http/JsonResponseTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace System\Test\Htpp;
+
+use PHPUnit\Framework\TestCase;
+use System\Http\JsonResponse;
+
+class JsonResponseTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itCanRenderJsonString(): void
+    {
+        $json_response = new JsonResponse([
+            'languange' => 'php',
+            'ver'       => 80,
+        ]);
+
+        ob_start();
+        $json_response->send();
+        $json = ob_get_clean();
+
+        $this->assertJson($json);
+        $data = json_decode($json, true);
+        $this->assertEquals($data, $json_response->getData());
+        $this->assertEquals(200, $json_response->getStatusCode());
+        $this->assertEquals('application/json', (fn () => $this->{'content_type'})->call($json_response));
+    }
+}

--- a/tests/Http/JsonResponseTest.php
+++ b/tests/Http/JsonResponseTest.php
@@ -89,9 +89,8 @@ class JsonResponseTest extends TestCase
      */
     public function itCanSetEncodingOptions(): void
     {
-        $this->markTestSkipped('need more inspeks');
         $response = new JsonResponse();
-        $response->setData([1, 2, 3]);
+        $response->setData([[1, 2, 3]]);
 
         $this->assertEquals('[[1,2,3]]', $response->getContent());
 

--- a/tests/Http/JsonResponseTest.php
+++ b/tests/Http/JsonResponseTest.php
@@ -32,9 +32,17 @@ class JsonResponseTest extends TestCase
     /**
      * @test
      */
+    public function itWillThrowsInvalidExcaption(): void
+    {
+        $this->expectExceptionMessage('Invalid encode data.');
+        new JsonResponse(['say' => "Hello \x80 World"]);
+    }
+
+    /**
+     * @test
+     */
     public function itConstructorEmptyCreatesJsonObject()
     {
-        $this->markTestSkipped();
         $response = new JsonResponse();
         $this->assertSame('{}', $response->getContent());
     }
@@ -67,9 +75,8 @@ class JsonResponseTest extends TestCase
      */
     public function itJsonEncodeFlags()
     {
-        $this->markTestSkipped('work but require setData');
         $response = new JsonResponse();
-        // $response->setData('<>\'&"');
+        $response->setData('<>\'&"');
 
         $this->assertEquals('"\u003C\u003E\u0027\u0026\u0022"', $response->getContent());
     }

--- a/tests/Http/JsonResponseTest.php
+++ b/tests/Http/JsonResponseTest.php
@@ -12,19 +12,91 @@ class JsonResponseTest extends TestCase
      */
     public function itCanRenderJsonString(): void
     {
-        $json_response = new JsonResponse([
+        $response = new JsonResponse([
             'languange' => 'php',
             'ver'       => 80,
         ]);
 
         ob_start();
-        $json_response->send();
+        $response->send();
         $json = ob_get_clean();
 
         $this->assertJson($json);
         $data = json_decode($json, true);
-        $this->assertEquals($data, $json_response->getData());
-        $this->assertEquals(200, $json_response->getStatusCode());
-        $this->assertEquals('application/json', (fn () => $this->{'content_type'})->call($json_response));
+        $this->assertEquals('{"languange":"php","ver":80}', $response->getContent());
+        $this->assertEquals($data, $response->getData());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->getContentType());
+    }
+
+    /**
+     * @test
+     */
+    public function itConstructorEmptyCreatesJsonObject()
+    {
+        $this->markTestSkipped();
+        $response = new JsonResponse();
+        $this->assertSame('{}', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function itConstructorWithArrayCreatesJsonArray()
+    {
+        $response = new JsonResponse([0, 1, 2, 3]);
+        $this->assertSame('[0,1,2,3]', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function itSetJson()
+    {
+        $response = new JsonResponse();
+        $response->setJson('1');
+        $this->assertEquals('1', $response->getContent());
+
+        $response = new JsonResponse();
+        $response->setJson('true');
+        $this->assertEquals('true', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function itJsonEncodeFlags()
+    {
+        $this->markTestSkipped('work but require setData');
+        $response = new JsonResponse();
+        // $response->setData('<>\'&"');
+
+        $this->assertEquals('"\u003C\u003E\u0027\u0026\u0022"', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function itGetEncodingOptions()
+    {
+        $response = new JsonResponse();
+
+        $this->assertEquals(\JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT, $response->getEncodingOptions());
+    }
+
+    /**
+     * @test
+     */
+    public function itCanSetEncodingOptions(): void
+    {
+        $this->markTestSkipped('need more inspeks');
+        $response = new JsonResponse();
+        $response->setData([1, 2, 3]);
+
+        $this->assertEquals('[[1,2,3]]', $response->getContent());
+
+        $response->setEncodingOptions(\JSON_FORCE_OBJECT);
+
+        $this->assertEquals('{"0":{"0":1,"1":2,"2":3}}', $response->getContent());
     }
 }


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **No**|
| New feature? | **Yes** |
| Breaks BC?   | **No**                                              |
| Fixed issues |  |

------
new json response class instead using `Response::json()`. json() will deprated and soon be removed, also content will alwasy as string. content type will follow the header.