### PR TITLE
Fix foreach syntax in EachTemplator

### DIFF
--- a/src/System/View/Templator/EachTemplator.php
+++ b/src/System/View/Templator/EachTemplator.php
@@ -11,14 +11,20 @@ class EachTemplator extends AbstractTemplatorParse
     public function parse(string $template): string
     {
         $template = preg_replace(
-            '/{%\s*foreach\s+([^%]+)\s+as\s+([^%]+)\s*=>\s*([^%]+)\s*%}(.*?){%\s*endforeach\s*%}/s',
-            '<?php foreach ($1 as $2 => $3): ?>$4<?php endforeach; ?>',
+            '/{%\s*foreach\s+([^%]+)\s+as\s+([^%]+)\s*=>\s*([^%]+)\s*%}/s',
+            '<?php foreach ($1 as $2 => $3): ?>',
             $template
         );
 
         $template = preg_replace(
-            '/{%\s*foreach\s+([^%]+)\s+as\s+([^%]+)\s*%}(.*?){%\s*endforeach\s*%}/s',
-            '<?php foreach ($1 as $2): ?>$3<?php endforeach; ?>',
+            '/{%\s*foreach\s+([^%]+)\s+as\s+([^%]+)\s*%}/s',
+            '<?php foreach ($1 as $2): ?>',
+            $template
+        );
+
+        $template = preg_replace(
+            '/{%\s*endforeach\s*%}/s',
+            '<?php endforeach; ?>',
             $template
         );
 

--- a/tests/View/Templator/EachTest.php
+++ b/tests/View/Templator/EachTest.php
@@ -16,8 +16,11 @@ final class EachTest extends TestCase
     public function itCanRenderEach()
     {
         $templator = new Templator(new TemplatorFinder([__DIR__], ['']), __DIR__);
-        $out       = $templator->templates('{% foreach $numbsers as $number %}{{ $number }}{% endforeach %}');
-        $this->assertEquals('<?php foreach ($numbsers as $number ): ?><?php echo htmlspecialchars($number ); ?><?php endforeach; ?>', $out);
+        $out       = $templator->templates('{% foreach $numbers as $number %}{{ $number }}{% endforeach %}');
+        $this->assertEquals(
+            '<?php foreach ($numbers as $number ): ?><?php echo htmlspecialchars($number ); ?><?php endforeach; ?>',
+            $out
+        );
     }
 
     /**
@@ -26,7 +29,49 @@ final class EachTest extends TestCase
     public function itCanRenderEachWithKeyValue()
     {
         $templator = new Templator(new TemplatorFinder([__DIR__], ['']), __DIR__);
-        $out       = $templator->templates('{% foreach $numbsers as $key => $number %}{{ $number }}{% endforeach %}');
-        $this->assertEquals('<?php foreach ($numbsers as $key  => $number ): ?><?php echo htmlspecialchars($number ); ?><?php endforeach; ?>', $out);
+        $out       = $templator->templates('{% foreach $numbers as $key => $number %}{{ $number }}{% endforeach %}');
+        $this->assertEquals(
+            '<?php foreach ($numbers as $key  => $number ): ?><?php echo htmlspecialchars($number ); ?><?php endforeach; ?>',
+            $out
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itCanRenderNestedEach()
+    {
+        $templator = new Templator(new TemplatorFinder([__DIR__], ['']), __DIR__);
+        $template  = '{% foreach $categories as $category %}{{ $category->name }}{% foreach $category->items as $item %}{{ $item->name }}{% endforeach %}{% endforeach %}';
+        $expected  = '<?php foreach ($categories as $category ): ?><?php echo htmlspecialchars($category->name ); ?><?php foreach ($category->items as $item ): ?><?php echo htmlspecialchars($item->name ); ?><?php endforeach; ?><?php endforeach; ?>';
+
+        $out = $templator->templates($template);
+        $this->assertEquals($expected, $out);
+    }
+
+    /**
+     * @test
+     */
+    public function itCanRenderNestedEachWithKeyValue()
+    {
+        $templator = new Templator(new TemplatorFinder([__DIR__], ['']), __DIR__);
+        $template  = '{% foreach $data as $key => $values %}{{ $key }}{% foreach $values as $index => $item %}{{ $index }}: {{ $item }}{% endforeach %}{% endforeach %}';
+        $expected  = '<?php foreach ($data as $key  => $values ): ?><?php echo htmlspecialchars($key ); ?><?php foreach ($values as $index  => $item ): ?><?php echo htmlspecialchars($index ); ?>: <?php echo htmlspecialchars($item ); ?><?php endforeach; ?><?php endforeach; ?>';
+
+        $out = $templator->templates($template);
+        $this->assertEquals($expected, $out);
+    }
+
+    /**
+     * @test
+     */
+    public function itCanRenderMultipleForeachBlocks()
+    {
+        $templator = new Templator(new TemplatorFinder([__DIR__], ['']), __DIR__);
+        $template  = '{% foreach $users as $user %}{{ $user->name }}{% endforeach %}{% foreach $products as $product %}{{ $product->name }}{% endforeach %}';
+        $expected  = '<?php foreach ($users as $user ): ?><?php echo htmlspecialchars($user->name ); ?><?php endforeach; ?><?php foreach ($products as $product ): ?><?php echo htmlspecialchars($product->name ); ?><?php endforeach; ?>';
+
+        $out = $templator->templates($template);
+        $this->assertEquals($expected, $out);
     }
 }


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **Yes**|
| New feature? | **No**|
| Breaks BC?   | **No**|
| Fixed issues |  |

------
Correct the foreach syntax in the EachTemplator class and update tests to reflect the changes. Add new tests for nested foreach and multiple foreach blocks.