### PR TITLE
Add PHP 8.4 to testing matrix in GitHub Actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
 
     name: Tests PHP ${{ matrix.php }}
 


### PR DESCRIPTION
Update the GitHub Actions workflow to include PHP 8.4 in the testing matrix.