### PR TITLE
Update NameTemplator to support unescaped variables

### DIFF
--- a/src/System/View/Templator/NameTemplator.php
+++ b/src/System/View/Templator/NameTemplator.php
@@ -17,10 +17,8 @@ class NameTemplator extends AbstractTemplatorParse
             return '##RAW_BLOCK##';
         }, $template);
 
-        $template = preg_replace('/{{\s*([^}]+)\s*\?\?\s*([^:}]+)\s*:\s*([^}]+)\s*}}/',
-            '<?php echo ($1 !== null) ? $1 : $3; ?>',
-            preg_replace('/{{\s*([^}]+)\s*}}/', '<?php echo htmlspecialchars($1); ?>', $template)
-        );
+        $template = preg_replace('/{!!\s*([^}]+)\s*!!}/', '<?php echo $1; ?>', $template);
+        $template = preg_replace('/{{\s*([^}]+)\s*}}/', '<?php echo htmlspecialchars($1); ?>', $template);
 
         foreach ($rawBlocks as $rawBlock) {
             $template = preg_replace('/##RAW_BLOCK##/', $rawBlock, $template, 1);

--- a/tests/View/Templator/NamingTest.php
+++ b/tests/View/Templator/NamingTest.php
@@ -23,6 +23,16 @@ final class NamingTest extends TestCase
     /**
      * @test
      */
+    public function itCanRenderNamingWithoutEscape()
+    {
+        $templator = new Templator(new TemplatorFinder([__DIR__], ['']), __DIR__);
+        $out       = $templator->templates('<html><head></head><body><h1>your {!! $name !!}, ages {!! $age !!} </h1></body></html>');
+        $this->assertEquals('<html><head></head><body><h1>your <?php echo $name ; ?>, ages <?php echo $age ; ?> </h1></body></html>', $out);
+    }
+
+    /**
+     * @test
+     */
     public function itCanRenderNamingWithCallFunction()
     {
         $templator = new Templator(new TemplatorFinder([__DIR__], ['']), __DIR__);


### PR DESCRIPTION
Enhance the NameTemplator to handle unescaped variables and add a corresponding test to verify this functionality.