### PR TITLE
[feat] Adding request parameters handling in Karnel

### DIFF
--- a/src/System/Integrate/Http/Karnel.php
+++ b/src/System/Integrate/Http/Karnel.php
@@ -64,6 +64,8 @@ class Karnel
 
             $dispatcher = $this->dispatcher($request);
 
+            $request->with($dispatcher['parameters']);
+
             $pipeline = array_reduce(
                 array_merge($this->middleware, $dispatcher['middleware']),
                 fn ($next, $middleware) => fn ($req) => $this->app->call([$middleware, 'handle'], ['request' => $req, 'next' => $next]),

--- a/tests/Integrate/Http/KarnelTest.php
+++ b/tests/Integrate/Http/KarnelTest.php
@@ -35,7 +35,9 @@ final class KarnelTest extends TestCase
             {
                 return [
                     'callable'   => fn () => new Response('ok', 200),
-                    'parameters' => [],
+                    'parameters' => [
+                        'foo' => 'bar',
+                    ],
                     'middleware' => [
                         new class {
                             public function handle(Request $request, Closure $next): Response
@@ -46,7 +48,11 @@ final class KarnelTest extends TestCase
                         new class {
                             public function handle(Request $request, Closure $next): Response
                             {
-                                return new Response('redirect', 303);
+                                if ($request->getAttribute('foo', null) === 'bar') {
+                                    return new Response('redirect', 303);
+                                }
+
+                                return $next($request);
                             }
                         },
                         new class {
@@ -71,7 +77,12 @@ final class KarnelTest extends TestCase
         $this->karnel = null;
     }
 
-    /** @test */
+    /**
+     * This test contain test for middleware and
+     * test for register request attribute.
+     *
+     * @test
+     */
     public function itCanRedirectByMiddleware()
     {
         $respone = $this->app->make(Karnel::class);


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **No**                                              |
| New feature? | **Yes**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues |  |

------
This pull request adding routers parameter to the requests attribute. we are adding in the began of middleware, it's make parameters can be access from Middleware event not yet touch the controller.
