### PR TITLE
[refacto] Correct typo in reduce method name and add deprecated alias

### DIFF
--- a/src/System/Collection/Collection.php
+++ b/src/System/Collection/Collection.php
@@ -411,13 +411,28 @@ class Collection extends AbstractCollectionImmutable
      *
      * @return TValue|null
      */
-    public function reduse(callable $callable, $carry = null)
+    public function reduce(callable $callable, $carry = null)
     {
         foreach ($this->collection as $item) {
             $carry = $callable($carry, $item);
         }
 
         return $carry;
+    }
+
+    /**
+     * Reduce items.
+     *
+     * @deprecated typo use `reduce` instead
+     *
+     * @param callable(TValue, TValue): TValue $callable
+     * @param TValue|null                      $carry
+     *
+     * @return TValue|null
+     */
+    public function reduse(callable $callable, $carry = null)
+    {
+        return $this->reduce($callable, $carry);
     }
 
     /**

--- a/tests/Collection/CollectionTest.php
+++ b/tests/Collection/CollectionTest.php
@@ -403,7 +403,7 @@ class CollectionTest extends TestCase
     {
         $collection = new Collection([1, 2, 3, 4]);
 
-        $sum = $collection->reduse(fn ($carry, $item) => $carry + $item);
+        $sum = $collection->reduce(fn ($carry, $item) => $carry + $item);
 
         $this->assertTrue($sum === 10);
     }


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **No**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **Yes**                                              |
| Fixed issues | |

------
deprecated typo method `reduse` and add `reduce`. nothing else.
