### PR TITLE
fix: missing route name

### DIFF
--- a/src/System/Router/Route.php
+++ b/src/System/Router/Route.php
@@ -12,7 +12,7 @@ use ArrayAccess;
 class Route implements \ArrayAccess
 {
     /** @var array<string, mixed> */
-    private $route;
+    private array $route;
     private string $prefix_name;
 
     /**
@@ -21,8 +21,9 @@ class Route implements \ArrayAccess
     public function __construct(array $route)
     {
         $this->prefix_name = Router::$group['as'] ?? '';
-        $route['name']     = $this->prefix_name;
-        $this->route       = $route;
+        $route['name'] ??= '';
+        $route['name'] = $this->prefix_name . $route['name'];
+        $this->route   = $route;
     }
 
     /**

--- a/tests/Router/NamedParameterRouteTest.php
+++ b/tests/Router/NamedParameterRouteTest.php
@@ -215,4 +215,49 @@ class NamedParameterRouteTest extends TestCase
             'Should handle special characters in parameters'
         );
     }
+
+    /**
+     * @test
+     */
+    public function itMakeSureRouterNameIsNotOverwritten(): void
+    {
+        $route = [
+            'name'    => 'test.route',
+            'path'    => '/test',
+            'method'  => 'get',
+            'handler' => function () {
+                echo 'Test Route';
+            },
+        ];
+        $routeInstance = new System\Router\Route($route);
+        $this->assertEquals('test.route', $routeInstance->route()['name'], 'Route name should not be overwritten');
+        $routeInstance->name('new.route');
+        $this->assertEquals('new.route', $routeInstance->route()['name'], 'Route name should remain unchanged after setting a new name');
+    }
+
+    /**
+     * Test the prefix name is always added the beaginning of the route name.
+     *
+     * @test
+     */
+    public function itMakesureRouterNameIsNotOverwrittenWithPrefixGivven(): void
+    {
+        $backup        = Router::$group;
+        Router::$group = ['as' => 'prefix.'];
+        $route         = [
+            'name'    => 'test.route',
+            'path'    => '/test',
+            'method'  => 'get',
+            'handler' => function () {
+                echo 'Test Route';
+            },
+        ];
+
+        $routeInstance = new System\Router\Route($route);
+        $this->assertEquals('prefix.test.route', $routeInstance['name'], 'Route name should not be overwritten');
+        $routeInstance->name('new.route');
+        $this->assertEquals('prefix.new.route', $routeInstance->route()['name'], 'Route name should remain unchanged after setting a new name');
+
+        Router::$group = $backup;
+    }
 }


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **Yes**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **YNo**                                              |
| Fixed issues | |

------
fix route name missing when initial (construction), it becouse the route name has been set ovverides with prefix withtoun actual route name. fix thi issue for #447.
