### PR TITLE
refactor, fix: allow redirect route with named paramters

### DIFF
--- a/src/System/Integrate/helper.php
+++ b/src/System/Integrate/helper.php
@@ -363,30 +363,12 @@ if (!function_exists('redirect_route')) {
     /**
      * Redirect to another route.
      *
-     * @param string[] $parameter Dinamic parameter to fill with url exprestion
+     * @param array<string|int, string|int|bool> $parameter Dinamic parameter to fill with url exprestion
      */
     function redirect_route(string $route_name, array $parameter = []): RedirectResponse
     {
         $route      = Router::redirect($route_name);
-        $valueIndex = 0;
-        $url        = preg_replace_callback(
-            "/\(:\w+\)/",
-            function ($matches) use ($parameter, &$valueIndex) {
-                if (!array_key_exists($matches[0], Router::$patterns)) {
-                    throw new Exception('parameter not matches with any pattern.');
-                }
-
-                if ($valueIndex < count($parameter)) {
-                    $value = $parameter[$valueIndex];
-                    $valueIndex++;
-
-                    return $value;
-                }
-
-                return '';
-            },
-            $route['uri']
-        );
+        $url        = Router::routeToUrl($route, $parameter);
 
         return new RedirectResponse($url);
     }

--- a/src/System/Router/Router.php
+++ b/src/System/Router/Router.php
@@ -292,6 +292,97 @@ class Router
     }
 
     /**
+     * @param array<string|int, string|int|bool> $parameters
+     */
+    public static function routeToUrl(Route $route, array $parameters): string
+    {
+        $url                = $route['uri'];
+        $paramIndex         = 0;
+        $pattern_map        = self::$patterns + ($route['patterns'] ?? []);
+        $isAssociativeArray = !array_is_list($parameters);
+
+        $url = preg_replace_callback('/\(([^:)]+):([^)]+)\)/', function ($matches) use ($parameters, $isAssociativeArray, &$paramIndex, $pattern_map) {
+            $paramName   = $matches[1];
+            $patternType = $matches[2];
+            $patternKey  = "(:{$patternType})";
+
+            if (false === isset($pattern_map[$patternKey])) {
+                throw new \InvalidArgumentException("Unknown pattern type: {$patternKey}");
+            }
+
+            $regex = $pattern_map[$patternKey];
+
+            if ($isAssociativeArray) {
+                if (false === isset($parameters[$paramName])) {
+                    throw new \InvalidArgumentException("Missing named parameter: {$paramName}");
+                }
+                $value = $parameters[$paramName];
+            } else {
+                if (false === isset($parameters[$paramIndex])) {
+                    throw new \InvalidArgumentException("Missing parameter at index {$paramIndex} for named parameter {$paramName}");
+                }
+                $value = $parameters[$paramIndex];
+                $paramIndex++;
+            }
+
+            $stringValue = (string) $value;
+            if (false === preg_match("/^{$regex}$/", $stringValue)) {
+                throw new \InvalidArgumentException("Named parameter '{$paramName}' with value '{$value}' doesn't match pattern {$patternKey} ({$regex})");
+            }
+
+            return $stringValue;
+        }, $url);
+
+        if ($isAssociativeArray) {
+            $paramIndex = 0;
+        }
+
+        foreach ($pattern_map as $pattern => $regex) {
+            while (strpos($url, $pattern) !== false) {
+                $value = null;
+
+                if ($isAssociativeArray) {
+                    $patternName = trim($pattern, '(:)');
+
+                    if (isset($parameters[$paramIndex])) {
+                        $value = $parameters[$paramIndex];
+                        $paramIndex++;
+                    } elseif (isset($parameters[$patternName])) {
+                        $value = $parameters[$patternName];
+                    } else {
+                        throw new \InvalidArgumentException("Missing parameter for pattern {$pattern}. Provide either numeric index {$paramIndex} or key '{$patternName}'");
+                    }
+                } else {
+                    if (false === isset($parameters[$paramIndex])) {
+                        throw new \InvalidArgumentException("Missing parameter at index {$paramIndex} for pattern {$pattern}");
+                    }
+                    $value = $parameters[$paramIndex];
+                    $paramIndex++;
+                }
+
+                $stringValue = (string) $value;
+                if (false === preg_match("/^{$regex}$/", $stringValue)) {
+                    throw new \InvalidArgumentException("Parameter '{$value}' doesn't match pattern {$pattern} ({$regex})");
+                }
+
+                $url = preg_replace('/' . preg_quote($pattern, '/') . '/', $stringValue, $url, 1);
+            }
+        }
+
+        if (preg_match('/\([^)]+:[^)]+\)/', $url)) {
+            throw new \InvalidArgumentException('Some named parameters were not replaced in URL');
+        }
+
+        foreach ($pattern_map as $pattern => $regex) {
+            if (strpos($url, $pattern) !== false) {
+                throw new \InvalidArgumentException("Not enough parameters provided. Pattern {$pattern} still exists in URL");
+            }
+        }
+
+        return $url;
+    }
+
+    /**
      * @param class-string            $class_name
      * @param array<string, string[]> $setup
      */

--- a/tests/Router/BasicRouteTest.php
+++ b/tests/Router/BasicRouteTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use System\Router\Route;
 use System\Router\Router;
 use System\Test\Router\Attribute\TestBasicRouteAttribute;
 use System\Test\Router\Attribute\TestRouteAttribute;
@@ -448,5 +449,31 @@ class BasicRouteTest extends TestCase
                 'name'       => 'test.test',
             ],
         ], $routes);
+    }
+
+    /**
+     * @test
+     */
+    public function itCanRebuildUrlFromRoute(): void
+    {
+        $url =  Router::routeToUrl(new Route([
+            'uri' => '/user/(:id)/posts',
+        ]), ['100']);
+        $this->assertEquals('/user/100/posts', $url);
+
+        $url =  Router::routeToUrl(new Route([
+            'uri' => '/user/(:id)/profile/(:slug)',
+        ]), ['123', 'john-doe']);
+        $this->assertEquals('/user/123/profile/john-doe', $url);
+
+        $url =  Router::routeToUrl(new Route([
+            'uri' => '/about',
+        ]), []);
+        $this->assertEquals('/about', $url);
+
+        $url =  Router::routeToUrl(new Route([
+            'uri' => '/posts/(:num)/(:text)',
+        ]), [2024, 'title']);
+        $this->assertEquals('/posts/2024/title', $url);
     }
 }

--- a/tests/Router/UrlBuilderTest.php
+++ b/tests/Router/UrlBuilderTest.php
@@ -1,0 +1,163 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use System\Router\Route;
+use System\Router\Router;
+
+class UrlBuilderTest extends TestCase
+{
+    /** @test */
+    public function itCanGenerateSimpleStandardPattern()
+    {
+        $this->assertSame(
+            '/user/123',
+            Router::routeToUrl(
+                new Route([
+                    'uri' => '/user/(:id)',
+                ]),
+                [123]
+            )
+        );
+    }
+
+    /** @test */
+    public function itCanGenerateMultipleStandardPatterns()
+    {
+        $this->assertSame(
+            '/user/123/profile/john-doe',
+            Router::routeToUrl(
+                new Route([
+                    'uri' => '/user/(:id)/profile/(:slug)',
+                ]),
+                [123, 'john-doe']
+            )
+        );
+    }
+
+    /** @test */
+    public function itCanGenerateWithNamedParametersOnly()
+    {
+        $this->assertSame(
+            '/absensi/456/today',
+            Router::routeToUrl(
+                new Route([
+                    'uri' => '/absensi/(identitas:id)/(tanggal:text)',
+                ]),
+                [
+                    'identitas' => 456,
+                    'tanggal'   => 'today',
+                ])
+        );
+    }
+
+    /** @test */
+    public function itCanMixIndexedAndNamedParameters()
+    {
+        $this->assertSame(
+            '/user/123/absensi/456/hari-ini',
+            Router::routeToUrl(
+                new Route([
+                    'uri' => '/user/(:id)/absensi/(identitas:id)/hari-ini',
+                ]),
+                [
+                    0           => 123,
+                    'identitas' => 456,
+                ])
+        );
+    }
+
+    /** @test */
+    public function itCanGenerateWithBasepath()
+    {
+        $this->assertSame(
+            '/admin/users/999/edit',
+            Router::routeToUrl(
+                new Route([
+                    'uri' => '/admin/(section:text)/(userId:id)/edit',
+                ]),
+                [
+                    'section' => 'users',
+                    'userId'  => 999,
+                ], '/backend')
+        );
+    }
+
+    /** @test */
+    public function itCanGenerateWithAllPatternTypes()
+    {
+        $this->assertSame(
+            '/api/1/query_123/page/5/active-users',
+            Router::routeToUrl(
+                new Route([
+                    'uri' => '/api/(:id)/(search:any)/page/(:num)/(filter:slug)',
+                ]),
+                [
+                    'id'     => 1,
+                    'search' => 'query_123',
+                    'num'    => 5,
+                    'filter' => 'active-users',
+                ])
+        );
+    }
+
+    /** @test */
+    public function itCanGenerateWithCustomPattern()
+    {
+        $this->assertSame(
+            '/color/ff00ff',
+            Router::routeToUrl(
+                new Route([
+                    'uri'      => '/color/(:hex)',
+                    'patterns' => ['(:hex)' => '([0-9a-fA-F]+)'],
+                ]),
+                ['ff00ff']
+            )
+        );
+    }
+
+    /** @test */
+    public function itCanHandleZeroAndEmptyStringValues()
+    {
+        $this->assertSame(
+            '/user/0/profile/',
+            Router::routeToUrl(
+                new Route([
+                    'uri' => '/user/(:id)/profile/(:text)',
+                ]),
+                [0, '']
+            )
+        );
+    }
+
+    /** @test */
+    public function itCanGenerateComplexNestedStyle()
+    {
+        $this->assertSame(
+            '/company/1/employee/456/profile/john-doe/large',
+            Router::routeToUrl(
+                new Route([
+                    'uri' => '/company/(:id)/employee/(empId:num)/profile/(:slug)/(avatar:text)',
+                ]),
+                [
+                    0        => 1,
+                    'empId'  => 456,
+                    1        => 'john-doe',
+                    'avatar' => 'large',
+                ])
+        );
+    }
+
+    /** @test */
+    public function itCanGenerateMultipleSamePatternTypes()
+    {
+        $this->assertSame(
+            '/tags/php/related/laravel',
+            Router::routeToUrl(
+                new Route([
+                    'uri' => '/tags/(:slug)/related/(:slug)',
+                ]),
+                ['php', 'laravel']
+            )
+        );
+    }
+}


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **Yes**                                              |
| New feature? | **Yes**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues | |

------
Allowed route redirect with named paramter, use new help call `routeToUrl` placed in `Router::class`.