### PR TITLE
fix: facade script generator `self` return type

### DIFF
--- a/bin/facade.php
+++ b/bin/facade.php
@@ -257,6 +257,7 @@ $command = new class($argv) extends Command {
         $buffer              = [];
         $methods             = [];
         $maxReturnTypeLength = 0;
+        $full_class_name     = '\\' . $class->getName();
         $ignore_method       = [
             'offsetExists' => true,
             'offsetGet'    => true,
@@ -300,6 +301,10 @@ $command = new class($argv) extends Command {
             $returnType ??= $method->hasReturnType()
                 ? $this->getTypeFromReflection($method->getReturnType())
                 : 'mixed';
+
+            if ('self' === $returnType) {
+                $returnType = $full_class_name;
+            }
 
             if (\strlen($returnType) > $maxReturnTypeLength) {
                 $maxReturnTypeLength = \strlen($returnType);


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **Yes**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues ||

------
FIx facade script generate full class name instead of `self`. This PR will fix phpstan return type not found.
