### PR TITLE
fix: add support parse without removeing quote

### DIFF
--- a/tests/Console/ConsoleParseTest.php
+++ b/tests/Console/ConsoleParseTest.php
@@ -42,6 +42,16 @@ class ConsoleParseTest extends TestCase
     }
 
     /** @test */
+    public function itCanParseCommandWithJson(): void
+    {
+        $command = 'php cli test --config=\'{"db":"mysql","port":3306}\'';
+        $argv    = explode(' ', $command);
+        $cli     = new Command($argv, ['default' => true]);
+
+        $this->assertEquals('{"db":"mysql","port":3306}', $cli->config);
+    }
+
+    /** @test */
     public function itCanParseNormalCommandWithSpace()
     {
         $command = 'php cli test --n jhoni -t -s --who-is children';


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **Yes**                                              |
| New feature? | **Yes**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues | |

------
Adding support parse without removeing quote, this help to get json or argument with original quote.

```bash
php script.php --config='{"db":"mysql","port":3306}'
```


