### PR TITLE
feat: console style pad

### DIFF
--- a/src/System/Console/Style/Style.php
+++ b/src/System/Console/Style/Style.php
@@ -626,4 +626,9 @@ class Style
     {
         return $this->repeat("\t", $repeat);
     }
+
+    public function pad(string $text, int $length, string $pad_string = '', int $pad_type = STR_PAD_RIGHT): self
+    {
+        return $this->push(str_pad($text, $length, $pad_string, $pad_type));
+    }
 }

--- a/tests/Console/Style/StyleTest.php
+++ b/tests/Console/Style/StyleTest.php
@@ -484,4 +484,14 @@ final class StyleTest extends TestCase
             $text
         );
     }
+
+    /** @test */
+    public function itCanRenderTextPad()
+    {
+        $cmd  = new Style('');
+        $text = $cmd->pad('red', 10, '*', STR_PAD_BOTH)
+        ;
+
+        $this->assertEquals(sprintf('%s[39;49m***red****%s[0m', chr(27), chr(27)), (string) $text);
+    }
 }


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **No**                                              |
| New feature? | **Yes**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues |  |

------
Add console style functionally by adding `pad` is similar with `repeat` but may help some case.

- render center table
- simple masking 
- simple alignment 
