### PR TITLE
feat: command exit const

### DIFF
--- a/src/System/Console/Command.php
+++ b/src/System/Console/Command.php
@@ -18,11 +18,9 @@ class Command implements \ArrayAccess
 {
     use TerminalTrait;
 
-    public const SUCCESS     = 0;
-    public const FAILURE     = 1;
-    public const INVALID     = 2;
-    public const NOT_EXECUTE = 126;
-    public const NOT_FOUND   = 127;
+    public const SUCCESS = 0;
+    public const FAILURE = 1;
+    public const INVALID = 2;
 
     public const VERBOSITY_SILENT       = 0;
     public const VERBOSITY_QUIET        = 1;

--- a/src/System/Console/Command.php
+++ b/src/System/Console/Command.php
@@ -18,6 +18,12 @@ class Command implements \ArrayAccess
 {
     use TerminalTrait;
 
+    public const SUCCESS     = 0;
+    public const FAILURE     = 1;
+    public const INVALID     = 2;
+    public const NOT_EXECUTE = 126;
+    public const NOT_FOUND   = 127;
+
     public const VERBOSITY_SILENT       = 0;
     public const VERBOSITY_QUIET        = 1;
     public const VERBOSITY_NORMAL       = 2;


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **No**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues |  |

------
For the shell’s purposes, a command which exits with a zero exit status has succeeded. So while an exit status of zero indicates success, a non-zero exit status indicates failure. This seemingly counter-intuitive scheme is used so there is one well-defined way to indicate success and a variety of ways to indicate various failure modes.

When a command terminates on a fatal signal whose number is N, Bash uses the value 128+N as the exit status.  