### PR TITLE
refacto: transaction throw exception will cancel transection directly

### DIFF
--- a/src/System/Database/MyPDO.php
+++ b/src/System/Database/MyPDO.php
@@ -381,20 +381,28 @@ class MyPDO
     }
 
     /**
+     * @param callable(): bool $callable
+     *
      * @return bool Transaction status
      */
-    public function transaction(callable $callable)
+    public function transaction(callable $callable): bool
     {
-        if (false === $this->beginTransaction()) {
+        try {
+            if (false === $this->beginTransaction()) {
+                return false;
+            }
+
+            $return_call =  call_user_func($callable);
+            if (false === $return_call) {
+                return $this->cancelTransaction();
+            }
+
+            return $this->endTransaction();
+        } catch (\Throwable $th) {
+            $this->cancelTransaction();
+
             return false;
         }
-
-        $return_call =  call_user_func($callable);
-        if (false === $return_call) {
-            return $this->cancelTransaction();
-        }
-
-        return $this->endTransaction();
     }
 
     /**

--- a/src/System/Database/MyPDO.php
+++ b/src/System/Database/MyPDO.php
@@ -381,7 +381,7 @@ class MyPDO
     }
 
     /**
-     * @param callable(): bool $callable
+     * @param callable(): bool|callable(static): bool $callable
      *
      * @return bool Transaction status
      */
@@ -392,7 +392,7 @@ class MyPDO
                 return false;
             }
 
-            $return_call =  call_user_func($callable);
+            $return_call =  call_user_func($callable, $this);
             if (true !== $return_call) {
                 $this->cancelTransaction();
 

--- a/src/System/Database/MyPDO.php
+++ b/src/System/Database/MyPDO.php
@@ -393,8 +393,10 @@ class MyPDO
             }
 
             $return_call =  call_user_func($callable);
-            if (false === $return_call) {
-                return $this->cancelTransaction();
+            if (true !== $return_call) {
+                $this->cancelTransaction();
+
+                return false;
             }
 
             return $this->endTransaction();

--- a/tests/DataBase/PDO/TransactionTest.php
+++ b/tests/DataBase/PDO/TransactionTest.php
@@ -72,7 +72,7 @@ final class TransactionTest extends TestDatabase
      *
      * @group database
      */
-    public function itCanCommitTransactionUsingCloser(): void
+    public function itCanCommitTransactionUsingClosure(): void
     {
         $this->pdo->query('INSERT INTO users (user, password, stat) VALUES (:user, :password, :stat)')
            ->bind(':user', 'test_user')
@@ -89,13 +89,44 @@ final class TransactionTest extends TestDatabase
             return true;
         };
 
-        $transection = $this->pdo->transaction($test);
+        $transaction = $this->pdo->transaction($test);
 
         $user = $this->pdo->query('SELECT * FROM users WHERE user = :user')
            ->bind(':user', 'test_user')
            ->resultset();
         $this->assertEquals(0, $user[0]['stat']);
-        $this->assertTrue($transection);
+        $this->assertTrue($transaction);
+    }
+
+    /**
+     * @test
+     *
+     * @group database
+     */
+    public function itCanCommitTransactionUsingClosureParameter(): void
+    {
+        $this->pdo->query('INSERT INTO users (user, password, stat) VALUES (:user, :password, :stat)')
+           ->bind(':user', 'test_user')
+           ->bind(':password', 'test_password')
+           ->bind(':stat', 1)
+           ->execute();
+
+        $test = function ($pdo): bool {
+            $pdo->query('UPDATE users SET stat = :stat WHERE user = :user')
+               ->bind(':stat', 0)
+               ->bind(':user', 'test_user')
+               ->execute();
+
+            return true;
+        };
+
+        $transaction = $this->pdo->transaction($test);
+
+        $user = $this->pdo->query('SELECT * FROM users WHERE user = :user')
+           ->bind(':user', 'test_user')
+           ->resultset();
+        $this->assertEquals(0, $user[0]['stat']);
+        $this->assertTrue($transaction);
     }
 
     /**
@@ -124,13 +155,13 @@ final class TransactionTest extends TestDatabase
             return false;
         };
 
-        $transection = $this->pdo->transaction($test);
+        $transaction = $this->pdo->transaction($test);
 
         $user = $this->pdo->query('SELECT * FROM users WHERE user = :user')
            ->bind(':user', 'test_user')
            ->resultset();
         $this->assertEquals(1, $user[0]['stat']);
-        $this->assertFalse($transection);
+        $this->assertFalse($transaction);
     }
 
     /**
@@ -157,12 +188,12 @@ final class TransactionTest extends TestDatabase
             return true;
         };
 
-        $transection =  $this->pdo->transaction($test);
+        $transaction =  $this->pdo->transaction($test);
 
         $user = $this->pdo->query('SELECT * FROM users WHERE user = :user')
            ->bind(':user', 'test_user')
            ->resultset();
         $this->assertEquals(1, $user[0]['stat']);
-        $this->assertFalse($transection);
+        $this->assertFalse($transaction);
     }
 }

--- a/tests/DataBase/PDO/TransactionTest.php
+++ b/tests/DataBase/PDO/TransactionTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace System\Test\Database\PDO;
+
+use System\Test\Database\TestDatabase;
+
+final class TransactionTest extends TestDatabase
+{
+    protected function setUp(): void
+    {
+        $this->createConnection();
+        $this->createUserSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dropConnection();
+    }
+
+    /**
+     * @test
+     *
+     * @group database
+     */
+    public function itCanRollbackTransaction()
+    {
+        $this->pdo->query('INSERT INTO users (user, password, stat) VALUES (:user, :password, :stat)')
+           ->bind(':user', 'test_user')
+           ->bind(':password', 'test_password')
+           ->bind(':stat', 1)
+           ->execute();
+        $this->pdo->beginTransaction();
+        $this->pdo->query('UPDATE users SET stat = :stat WHERE user = :user')
+           ->bind(':stat', 0)
+           ->bind(':user', 'test_user')
+           ->execute();
+        $this->pdo->cancelTransaction();
+        $user = $this->pdo->query('SELECT * FROM users WHERE user = :user')
+           ->bind(':user', 'test_user')
+           ->resultset();
+        $this->assertEquals(1, $user[0]['stat']);
+    }
+
+    /**
+     * @test
+     *
+     * @group database
+     */
+    public function itCanCommitTransaction()
+    {
+        $this->pdo->query('INSERT INTO users (user, password, stat) VALUES (:user, :password, :stat)')
+           ->bind(':user', 'test_user')
+           ->bind(':password', 'test_password')
+           ->bind(':stat', 1)
+           ->execute();
+        $this->pdo->beginTransaction();
+        $this->pdo->query('UPDATE users SET stat = :stat WHERE user = :user')
+           ->bind(':stat', 0)
+           ->bind(':user', 'test_user')
+           ->execute();
+        $this->pdo->endTransaction();
+        $user = $this->pdo->query('SELECT * FROM users WHERE user = :user')
+           ->bind(':user', 'test_user')
+           ->resultset();
+        $this->assertEquals(0, $user[0]['stat']);
+    }
+
+    /**
+     * @test
+     *
+     * @group database
+     */
+    public function itCanCommitTransactionUsingCloser(): void
+    {
+        $this->pdo->query('INSERT INTO users (user, password, stat) VALUES (:user, :password, :stat)')
+           ->bind(':user', 'test_user')
+           ->bind(':password', 'test_password')
+           ->bind(':stat', 1)
+           ->execute();
+
+        $test = function (): bool {
+            $this->pdo->query('UPDATE users SET stat = :stat WHERE user = :user')
+               ->bind(':stat', 0)
+               ->bind(':user', 'test_user')
+               ->execute();
+
+            return true;
+        };
+
+        $transection = $this->pdo->transaction($test);
+
+        $user = $this->pdo->query('SELECT * FROM users WHERE user = :user')
+           ->bind(':user', 'test_user')
+           ->resultset();
+        $this->assertEquals(0, $user[0]['stat']);
+        $this->assertTrue($transection);
+    }
+
+    /**
+     * @test
+     *
+     * @group database
+     */
+    public function itCanRollbackTransactionUsingCloser(): void
+    {
+        $this->pdo->query('INSERT INTO users (user, password, stat) VALUES (:user, :password, :stat)')
+           ->bind(':user', 'test_user')
+           ->bind(':password', 'test_password')
+           ->bind(':stat', 1)
+           ->execute();
+
+        $test = function (): bool {
+            $this->pdo->query('UPDATE users SET stat = :stat WHERE user = :user')
+               ->bind(':stat', 0)
+               ->bind(':user', 'test_user')
+               ->execute();
+            $this->pdo->query('UPDATE users SET stat = :stat WHERE user = :user')
+               ->bind(':stat', 2)
+               ->bind(':user', 'test_user')
+               ->execute();
+
+            return false;
+        };
+
+        $transection = $this->pdo->transaction($test);
+
+        $user = $this->pdo->query('SELECT * FROM users WHERE user = :user')
+           ->bind(':user', 'test_user')
+           ->resultset();
+        $this->assertEquals(1, $user[0]['stat']);
+        $this->assertTrue($transection);
+    }
+
+    /**
+     * @test
+     *
+     * @group database
+     */
+    public function itCanRollbackTransactionUsingCloserWithThrow(): void
+    {
+        $this->pdo->query('INSERT INTO users (user, password, stat) VALUES (:user, :password, :stat)')
+           ->bind(':user', 'test_user')
+           ->bind(':password', 'test_password')
+           ->bind(':stat', 1)
+           ->execute();
+
+        $test = function (): bool {
+            $this->pdo->query('UPDATE users SET stat = :stat WHERE user = :user')
+               ->bind(':stat', 0)
+               ->bind(':user', 'test_user')
+               ->execute();
+
+            throw new \PDOException('Test Exception');
+
+            return true;
+        };
+
+        $transection =  $this->pdo->transaction($test);
+
+        $user = $this->pdo->query('SELECT * FROM users WHERE user = :user')
+           ->bind(':user', 'test_user')
+           ->resultset();
+        $this->assertEquals(1, $user[0]['stat']);
+        $this->assertFalse($transection);
+    }
+}

--- a/tests/DataBase/PDO/TransactionTest.php
+++ b/tests/DataBase/PDO/TransactionTest.php
@@ -130,7 +130,7 @@ final class TransactionTest extends TestDatabase
            ->bind(':user', 'test_user')
            ->resultset();
         $this->assertEquals(1, $user[0]['stat']);
-        $this->assertTrue($transection);
+        $this->assertFalse($transection);
     }
 
     /**


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **No**                                              |
| New feature? | **Yes**                                              |
| Breaks BC?   | **No**                             |
| Fixed issues | #444 |

------
Auto rollback when pdo transection got failed 
