### PR TITLE
refactor: use database manager as PDO accessor

### DIFF
--- a/resources/facades.php
+++ b/resources/facades.php
@@ -16,7 +16,7 @@ return [
     'DB'       => 'System\\Database\\MyQuery',
     'Hash'     => 'System\\Security\\Hashing\\HashManager',
     'PDO'      => [
-        'accessor' => 'System\\Database\\MyPDO',
+        'accessor' => 'System\\Database\\DatabaseManager',
         'with'     => [
             'resultset' => [
                 'return' => 'mixed[]|false',

--- a/src/System/Integrate/Console/MigrationCommand.php
+++ b/src/System/Integrate/Console/MigrationCommand.php
@@ -9,7 +9,6 @@ use System\Console\Command;
 use System\Console\Prompt;
 use System\Console\Style\Style;
 use System\Console\Traits\PrintHelpTrait;
-use System\Database\MyQuery;
 use System\Database\MySchema\MyPDO;
 use System\Database\MySchema\Table\Create;
 use System\Support\Facades\DB;
@@ -497,8 +496,7 @@ class MigrationCommand extends Command
         $width   = $this->getWidth(40, 60);
         info('showing database')->out(false);
 
-        $tables = PDO::instance()
-            ->query('SHOW DATABASES')
+        $tables = PDO::query('SHOW DATABASES')
             ->query('
                 SELECT table_name, create_time, ROUND((DATA_LENGTH + INDEX_LENGTH) / 1024 / 1024) AS `size`
                 FROM information_schema.tables
@@ -531,7 +529,7 @@ class MigrationCommand extends Command
 
     public function tableShow(string $table): int
     {
-        $table = (new MyQuery(PDO::instance()))->table($table)->info();
+        $table = DB::table($table)->info();
         $print = new Style("\n");
         $width = $this->getWidth(40, 60);
 
@@ -611,7 +609,7 @@ class MigrationCommand extends Command
      */
     private function hasMigrationTable(): bool
     {
-        $result = PDO::instance()->query(
+        $result = PDO::query(
             "SELECT COUNT(table_name) as total
             FROM information_schema.tables
             WHERE table_schema = DATABASE()

--- a/src/System/Support/Facades/PDO.php
+++ b/src/System/Support/Facades/PDO.php
@@ -5,30 +5,34 @@ declare(strict_types=1);
 namespace System\Support\Facades;
 
 /**
- * @method static \System\Database\MyPDO                                                                                                                                            instance()
- * @method static MyPDO                                                                                                                                                             conn(array<string, string> $configs)
- * @method static array{driver: string, host: ?string, database: ?string, port: ?int, charset: ?string, username: ?string, password: ?string, options: array<int, string|int|bool>} configs()
- * @method static string                                                                                                                                                            getDsn(array{host: string, driver: 'mysql'|'mariadb'|'pgsql'|'sqlite', database: ?string, port: ?int, charset: ?string} $configs)
- * @method static \System\Database\MyPDO                                                                                                                                            query(string $query)
- * @method static \System\Database\MyPDO                                                                                                                                            bind(string|int|bool|null $param, mixed $value, string|int|bool|null $type = null)
- * @method static bool                                                                                                                                                              execute()
- * @method static mixed[]|false                                                                                                                                                     resultset()
- * @method static mixed                                                                                                                                                             single()
- * @method static int                                                                                                                                                               rowCount()
- * @method static string|false                                                                                                                                                      lastInsertId()
- * @method static bool                                                                                                                                                              transaction(callable $callable)
- * @method static bool                                                                                                                                                              beginTransaction()
- * @method static bool                                                                                                                                                              endTransaction()
- * @method static bool                                                                                                                                                              cancelTransaction()
- * @method static void                                                                                                                                                              flushLogs()
- * @method static array<int, array<string, float|string|null>>                                                                                                                      getLogs()
+ * @method static void                                            clearConnections()
+ * @method static \System\Database\Interfaces\ConnectionInterface connection(string $name)
+ * @method static \System\Database\DatabaseManager                setDefaultConnection(\System\Database\Interfaces\ConnectionInterface $connection)
+ * @method static \System\Database\DatabaseManager                query(string $query)
+ * @method static \System\Database\DatabaseManager                bind(string|int|bool|null $param, mixed $value, string|int|bool|null $type = null)
+ * @method static bool                                            execute()
+ * @method static mixed[]|false                                   resultset()
+ * @method static mixed                                           single()
+ * @method static int                                             rowCount()
+ * @method static bool                                            transaction(callable $callable)
+ * @method static bool                                            beginTransaction()
+ * @method static bool                                            endTransaction()
+ * @method static bool                                            cancelTransaction()
+ * @method static string|false                                    lastInsertId()
+ * @method static void                                            flushLogs()
+ * @method static array<int, array<string, float|string|null>>    getLogs()
  *
- * @see System\Database\MyPDO
+ * @see System\Database\DatabaseManager
  */
 final class PDO extends Facade
 {
     protected static function getAccessor()
     {
-        return \System\Database\MyPDO::class;
+        return \System\Database\DatabaseManager::class;
+    }
+
+    public static function instance(): \System\Database\DatabaseManager
+    {
+        return self::getFacade();
     }
 }

--- a/tests/Integrate/Commands/MigrationCommandsTest.php
+++ b/tests/Integrate/Commands/MigrationCommandsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace System\Test\Integrate\Commands;
 
+use System\Database\DatabaseManager;
 use System\Database\MyPDO;
 use System\Database\MySchema;
 use System\Database\MySchema\Table\Create;
@@ -29,6 +30,7 @@ final class MigrationCommandsTest extends TestDatabase
         $this->app->set(MySchema\MyPDO::class, fn () => $this->pdo_schema);
         $this->app->set('MySchema', fn () => $this->schema);
         $this->app->set('dsn.sql', fn () => $this->env);
+        $this->app->set(DatabaseManager::class, fn () => $this->db);
 
         Facade::setFacadeBase($this->app);
         Schema::table('migration', function (Create $column) {


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **No**                                              |
| New feature? | **Yes**                                              |
| Breaks BC?   | **Yes**                                              |
| Fixed issues |  |

------
Refactor PDO Facade to use `DatabaseManager` as accessor intead pf `MyPDO`. Because no longger use `MyPDO` as accossor some method not include may broken the api. The Database manager has same Interface with `MyPDO`, we use `ConnectionInterface`. This list of mmethod not cover by interface (BC).
1. conn()
2. configs()
3. getDsn()